### PR TITLE
Implement process kill functionality

### DIFF
--- a/ros2top/node_monitor.py
+++ b/ros2top/node_monitor.py
@@ -106,19 +106,26 @@ class NodeMonitor:
     
     def _remove_dead_nodes(self, current_nodes: List[str]):
         """Remove processes for nodes that no longer exist"""
-        nodes_to_remove = [node for node in self.processes if node not in current_nodes]
-        for node in nodes_to_remove:
-            del self.processes[node]
+        # Convert current_nodes to set of unique keys for comparison
+        current_unique_keys = set()
+        for node_name, pid in self._get_all_processes_to_monitor():
+            current_unique_keys.add(f"{node_name}:{pid}")
+        
+        nodes_to_remove = [key for key in self.processes if key not in current_unique_keys]
+        for key in nodes_to_remove:
+            del self.processes[key]
     
     def _add_new_nodes_with_pids(self, nodes_with_pids: List[Tuple[str, int]]):
         """Add new nodes to monitoring using pre-discovered PIDs"""
         for node, pid in nodes_with_pids:
-            if node not in self.processes:
+            # Use a unique key combining node name and PID to allow multiple nodes with same name
+            unique_key = f"{node}:{pid}"
+            if unique_key not in self.processes:
                 try:
                     proc = psutil.Process(pid)
                     # Initialize CPU measurement
                     proc.cpu_percent()
-                    self.processes[node] = proc
+                    self.processes[unique_key] = proc
                 except psutil.NoSuchProcess:
                     pass
     
@@ -144,8 +151,11 @@ class NodeMonitor:
         """
         node_infos = []
         
-        for node_name, process in self.processes.items():
+        for unique_key, process in self.processes.items():
             try:
+                # Extract original node name from unique key (format: "node_name:pid")
+                node_name = unique_key.rsplit(':', 1)[0]
+                
                 # Get CPU usage (normalized by number of cores)
                 raw_cpu = process.cpu_percent()
                 cpu_pct = raw_cpu / self.cores if self.cores > 0 else raw_cpu
@@ -206,6 +216,59 @@ class NodeMonitor:
     def force_refresh(self):
         """Force refresh of node list on next update"""
         self.last_refresh = 0.0
+    
+    def kill_process(self, node_name: str, pid: int = None, force: bool = False) -> bool:
+        """
+        Kill a monitored process
+        
+        Args:
+            node_name: Name of the node/process to kill
+            pid: Specific PID to kill (optional, if not provided kills first match)
+            force: If True, use SIGKILL instead of SIGTERM
+            
+        Returns:
+            True if kill was successful, False otherwise
+        """
+        # Find the process to kill
+        process_to_kill = None
+        key_to_remove = None
+        
+        if pid is not None:
+            # Look for specific node name and PID combination
+            unique_key = f"{node_name}:{pid}"
+            if unique_key in self.processes:
+                process_to_kill = self.processes[unique_key]
+                key_to_remove = unique_key
+        else:
+            # Find first process matching the node name
+            for key, process in self.processes.items():
+                if key.startswith(f"{node_name}:"):
+                    process_to_kill = process
+                    key_to_remove = key
+                    break
+        
+        if process_to_kill is None:
+            return False
+            
+        try:
+            if force:
+                # Force kill with SIGKILL
+                process_to_kill.kill()
+            else:
+                # Graceful termination with SIGTERM
+                process_to_kill.terminate()
+            
+            # Wait briefly to see if process terminates
+            try:
+                process_to_kill.wait(timeout=1.0)
+            except psutil.TimeoutExpired:
+                # Process didn't terminate within timeout
+                pass
+                
+            return True
+            
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            return False
     
     def shutdown(self):
         """Clean shutdown of monitoring"""

--- a/ros2top/node_registry.py
+++ b/ros2top/node_registry.py
@@ -515,7 +515,7 @@ def _remove_node_registration_by_pid(pid: int) -> bool:
 
 def _update_node_heartbeat_by_pid(pid: int) -> bool:
     """Update the last_seen timestamp for a node by PID with file locking"""
-    import shutil
+    
     
     try:
         if not os.path.exists(REGISTRATION_FILE):

--- a/ros2top/node_registry.py
+++ b/ros2top/node_registry.py
@@ -98,8 +98,10 @@ def unregister_node(node_name: str) -> bool:
         # Normalize node name
         if not node_name.startswith('/'):
             node_name = f'/{node_name}'
-            
-        success = _remove_node_registration(node_name)
+        
+        # Find the PID for this node name from current process
+        current_pid = os.getpid()
+        success = _remove_node_registration_by_pid(current_pid)
         
         if success and node_name in _registered_nodes:
             _registered_nodes.remove(node_name)
@@ -121,11 +123,9 @@ def heartbeat(node_name: str) -> bool:
         True if heartbeat was successful, False otherwise
     """
     try:
-        # Normalize node name
-        if not node_name.startswith('/'):
-            node_name = f'/{node_name}'
-            
-        return _update_node_heartbeat(node_name)
+        # Use current process PID to update heartbeat
+        current_pid = os.getpid()
+        return _update_node_heartbeat_by_pid(current_pid)
         
     except Exception:
         return False
@@ -144,17 +144,19 @@ def get_registered_nodes() -> List[Tuple[str, int]]:
         # Filter out stale registrations (only check if process is still running)
         active_nodes = []
         
-        for node_name, data in nodes_data.items():
+        for pid_str, data in nodes_data.items():
             # Check if process is still running
             try:
-                proc = psutil.Process(data['pid'])
+                pid = int(pid_str)
+                proc = psutil.Process(pid)
                 if proc.is_running():
                     # Process is running, include it regardless of heartbeat timing
-                    active_nodes.append((node_name, data['pid']))
+                    node_name = data.get('node_name', f'/process_{pid}')
+                    active_nodes.append((node_name, pid))
                 # Note: If heartbeats are being sent, we could add additional logic here
                 # to detect unresponsive but running nodes
-            except psutil.NoSuchProcess:
-                # Process no longer exists, will be cleaned up later
+            except (psutil.NoSuchProcess, ValueError):
+                # Process no longer exists or invalid PID, will be cleaned up later
                 pass
                 
         return active_nodes
@@ -196,17 +198,19 @@ def cleanup_stale_registrations() -> int:
         nodes_data = _read_node_registrations()
         stale_nodes = []
         
-        for node_name, data in nodes_data.items():
+        for pid_str, data in nodes_data.items():
             try:
-                proc = psutil.Process(data['pid'])
+                pid = int(pid_str)
+                proc = psutil.Process(pid)
                 if not proc.is_running():
-                    stale_nodes.append(node_name)
-            except psutil.NoSuchProcess:
-                stale_nodes.append(node_name)
+                    stale_nodes.append(pid_str)
+            except (psutil.NoSuchProcess, ValueError):
+                stale_nodes.append(pid_str)
                 
         # Remove stale nodes
-        for node_name in stale_nodes:
-            _remove_node_registration(node_name)
+        for pid_str in stale_nodes:
+            pid = int(pid_str)
+            _remove_node_registration_by_pid(pid)
             
         return len(stale_nodes)
         
@@ -278,8 +282,8 @@ def _write_node_registration(node_data: Dict) -> bool:
                         # If JSON is corrupted, start fresh
                         existing_data = {}
             
-            # Update with new node data
-            existing_data[node_data['node_name']] = node_data
+            # Update with new node data - use PID as key to allow multiple nodes with same name
+            existing_data[str(node_data['pid'])] = node_data
             
             # Write to temporary file first, then rename (atomic operation)
             temp_file = REGISTRATION_FILE + '.tmp'
@@ -425,6 +429,142 @@ def _update_node_heartbeat(node_name: str) -> bool:
                 return True
                 
             return False
+            
+        finally:
+            # Always clean up lock file
+            try:
+                os.remove(LOCK_FILE)
+            except FileNotFoundError:
+                pass
+        
+    except Exception:
+        # Clean up lock file on error
+        try:
+            os.remove(LOCK_FILE)
+        except FileNotFoundError:
+            pass
+        return False
+
+
+def _remove_node_registration_by_pid(pid: int) -> bool:
+    """Remove node registration by PID from file with file locking"""
+    import shutil
+    
+    try:
+        if not os.path.exists(REGISTRATION_FILE):
+            return True
+        
+        # Create a lock file approach compatible with C++
+        lock_acquired = False
+        max_attempts = 100  # 1 second timeout
+        
+        for _ in range(max_attempts):
+            try:
+                # Try to create lock file exclusively
+                with open(LOCK_FILE, 'x') as lock_file:
+                    lock_file.write(str(os.getpid()))
+                    lock_acquired = True
+                    break
+            except FileExistsError:
+                # Lock file exists, wait and retry
+                time.sleep(0.01)
+                continue
+        
+        if not lock_acquired:
+            return False
+        
+        try:
+            # Read existing data
+            with open(REGISTRATION_FILE, 'r') as f:
+                try:
+                    existing_data = json.load(f)
+                except json.JSONDecodeError:
+                    # If JSON is corrupted, nothing to remove
+                    return True
+            
+            # Remove the node if it exists
+            pid_str = str(pid)
+            if pid_str in existing_data:
+                del existing_data[pid_str]
+                
+                # Write to temporary file first, then rename (atomic operation)
+                temp_file = REGISTRATION_FILE + '.tmp'
+                with open(temp_file, 'w') as f:
+                    json.dump(existing_data, f, indent=2)
+                
+                # Atomic rename
+                shutil.move(temp_file, REGISTRATION_FILE)
+                
+            return True
+            
+        finally:
+            # Always clean up lock file
+            try:
+                os.remove(LOCK_FILE)
+            except FileNotFoundError:
+                pass
+        
+    except Exception:
+        # Clean up lock file on error
+        try:
+            os.remove(LOCK_FILE)
+        except FileNotFoundError:
+            pass
+        return False
+
+
+def _update_node_heartbeat_by_pid(pid: int) -> bool:
+    """Update the last_seen timestamp for a node by PID with file locking"""
+    import shutil
+    
+    try:
+        if not os.path.exists(REGISTRATION_FILE):
+            return False
+        
+        # Create a lock file approach compatible with C++
+        lock_acquired = False
+        max_attempts = 100  # 1 second timeout
+        
+        for _ in range(max_attempts):
+            try:
+                # Try to create lock file exclusively
+                with open(LOCK_FILE, 'x') as lock_file:
+                    lock_file.write(str(os.getpid()))
+                    lock_acquired = True
+                    break
+            except FileExistsError:
+                # Lock file exists, wait and retry
+                time.sleep(0.01)
+                continue
+        
+        if not lock_acquired:
+            return False
+        
+        try:
+            # Read existing data
+            with open(REGISTRATION_FILE, 'r') as f:
+                try:
+                    existing_data = json.load(f)
+                except json.JSONDecodeError:
+                    # If JSON is corrupted, can't update
+                    return False
+            
+            # Update heartbeat if node exists
+            pid_str = str(pid)
+            if pid_str in existing_data:
+                existing_data[pid_str]['last_seen'] = time.time()
+                
+                # Write to temporary file first, then rename (atomic operation)
+                temp_file = REGISTRATION_FILE + '.tmp'
+                with open(temp_file, 'w') as f:
+                    json.dump(existing_data, f, indent=2)
+                
+                # Atomic rename
+                shutil.move(temp_file, REGISTRATION_FILE)
+                
+                return True
+            else:
+                return False
             
         finally:
             # Always clean up lock file

--- a/ros2top/node_registry.py
+++ b/ros2top/node_registry.py
@@ -209,8 +209,12 @@ def cleanup_stale_registrations() -> int:
                 
         # Remove stale nodes
         for pid_str in stale_nodes:
-            pid = int(pid_str)
-            _remove_node_registration_by_pid(pid)
+            try:
+                pid = int(pid_str)
+                _remove_node_registration_by_pid(pid)
+            except ValueError:
+                # Skip entries with invalid PID strings
+                continue
             
         return len(stale_nodes)
         

--- a/ros2top/node_registry.py
+++ b/ros2top/node_registry.py
@@ -448,7 +448,6 @@ def _update_node_heartbeat(node_name: str) -> bool:
 
 def _remove_node_registration_by_pid(pid: int) -> bool:
     """Remove node registration by PID from file with file locking"""
-    import shutil
     
     try:
         if not os.path.exists(REGISTRATION_FILE):

--- a/ros2top/ui/terminal_ui.py
+++ b/ros2top/ui/terminal_ui.py
@@ -42,6 +42,10 @@ class TerminalUI:
         self.last_update = 0
         self.update_interval = 1.0  # seconds
         self.paused = False
+        self.selected_row = 0  # Currently selected row in table
+        self.show_kill_dialog = False
+        self.kill_dialog_node = None
+        self.kill_dialog_pid = None
         
         # Statistics
         self.stats = {
@@ -283,6 +287,10 @@ class TerminalUI:
             # Draw layout manager components (table)
             self.layout_manager.draw(self.colors)
             
+            # Draw kill dialog if active
+            if self.show_kill_dialog:
+                self._draw_kill_dialog()
+            
             self.stdscr.refresh()
             self.last_update = current_time
             
@@ -396,7 +404,7 @@ class TerminalUI:
             section = self.controls_section
             
             # Line 1: Main controls
-            controls_line1 = "q:Quit  h:Help  r:Refresh  p:Pause/Resume  ↑↓:Navigate  Tab:Focus"
+            controls_line1 = "q:Quit  h:Help  r:Refresh  p:Pause/Resume  ↑↓:Navigate  k:Kill  Tab:Focus"
             self._addstr_with_color(section['start_y'], 0, controls_line1[:section['width']], 0)
             
             # Line 2: Status and additional info
@@ -518,6 +526,11 @@ class TerminalUI:
             rows.append(row)
         
         self.nodes_table.set_data(rows)
+        
+        # Sync selection state with table component
+        if rows:
+            self.selected_row = min(self.selected_row, len(rows) - 1)
+            self.nodes_table.selected_row = self.selected_row
     
     def _handle_input(self):
         """Handle keyboard input"""
@@ -540,6 +553,23 @@ class TerminalUI:
                 self.update_interval = max(0.5, self.update_interval - 0.5)
             elif key == ord('-'):
                 self.update_interval = min(5.0, self.update_interval + 0.5)
+            elif key == curses.KEY_UP:
+                self._move_selection(-1)
+            elif key == curses.KEY_DOWN:
+                self._move_selection(1)
+            elif key == ord('k') or key == ord('K'):
+                self._show_kill_dialog()
+            elif key == ord('y') or key == ord('Y'):
+                if self.show_kill_dialog:
+                    self._confirm_kill()
+            elif key == ord('n') or key == ord('N'):
+                if self.show_kill_dialog:
+                    self._cancel_kill()
+            elif key == 27:  # ESC key
+                if self.show_kill_dialog:
+                    self._cancel_kill()
+                else:
+                    self.show_help = False
             else:
                 # Pass to layout manager
                 if self.layout_manager:
@@ -570,6 +600,11 @@ class TerminalUI:
             "  ↑/↓      - Navigate table rows",
             "  Tab      - Switch focus between panels",
             "  Home/End - Jump to first/last row",
+            "",
+            "Process Control:",
+            "  k/K      - Kill selected process",
+            "  y/Y      - Confirm kill operation",
+            "  n/N/ESC  - Cancel kill operation",
             "",
             "Features:",
             "  • Responsive layout adapts to terminal size",
@@ -628,6 +663,76 @@ class TerminalUI:
         except curses.error:
             pass
     
+    def _move_selection(self, direction: int):
+        """Move selection up or down"""
+        nodes = self.monitor.get_node_info_list()
+        if not nodes:
+            return
+            
+        self.selected_row = max(0, min(len(nodes) - 1, self.selected_row + direction))
+    
+    def _show_kill_dialog(self):
+        """Show kill confirmation dialog for selected node"""
+        nodes = self.monitor.get_node_info_list()
+        if not nodes or self.selected_row >= len(nodes):
+            return
+            
+        selected_node = nodes[self.selected_row]
+        self.kill_dialog_node = selected_node.name
+        self.kill_dialog_pid = selected_node.pid
+        self.show_kill_dialog = True
+    
+    def _confirm_kill(self):
+        """Confirm and execute kill operation"""
+        if self.kill_dialog_node and self.kill_dialog_pid:
+            success = self.monitor.kill_process(self.kill_dialog_node, self.kill_dialog_pid)
+            if success:
+                # Force refresh to update display
+                self.monitor.force_refresh()
+            
+        self._cancel_kill()
+    
+    def _cancel_kill(self):
+        """Cancel kill operation"""
+        self.show_kill_dialog = False
+        self.kill_dialog_node = None
+        self.kill_dialog_pid = None
+    
+    def _draw_kill_dialog(self):
+        """Draw kill confirmation dialog"""
+        if not self.show_kill_dialog or not self.kill_dialog_node:
+            return
+            
+        try:
+            max_y, max_x = self.stdscr.getmaxyx()
+            
+            # Dialog dimensions
+            dialog_width = min(50, max_x - 4)
+            dialog_height = 8
+            dialog_x = (max_x - dialog_width) // 2
+            dialog_y = (max_y - dialog_height) // 2
+            
+            # Draw dialog background
+            for i in range(dialog_height):
+                self.stdscr.addstr(dialog_y + i, dialog_x, " " * dialog_width, curses.color_pair(4))
+            
+            # Dialog content
+            title = "KILL PROCESS"
+            node_line = f"Node: {self.kill_dialog_node}"
+            pid_line = f"PID: {self.kill_dialog_pid}"
+            warning = "This will terminate the selected process!"
+            confirm_line = "Continue? (Y)es / (N)o / (ESC) Cancel"
+            
+            # Center text in dialog
+            self._addstr_with_color(dialog_y + 1, dialog_x + (dialog_width - len(title)) // 2, title, 4)
+            self._addstr_with_color(dialog_y + 2, dialog_x + 2, node_line[:dialog_width-4], 0)
+            self._addstr_with_color(dialog_y + 3, dialog_x + 2, pid_line[:dialog_width-4], 0)
+            self._addstr_with_color(dialog_y + 4, dialog_x + 2, warning[:dialog_width-4], 3)
+            self._addstr_with_color(dialog_y + 6, dialog_x + 2, confirm_line[:dialog_width-4], 0)
+            
+        except curses.error:
+            pass
+
     def _show_error(self, message: str):
         """Show error message"""
         try:

--- a/tests/test_ros2top.py
+++ b/tests/test_ros2top.py
@@ -15,6 +15,7 @@ from ros2top.ros2_utils import is_ros2_available, get_ros2_nodes, get_ros2_nodes
 from ros2top.gpu_monitor import GPUMonitor
 from ros2top.node_monitor import NodeMonitor, NodeInfo
 from ros2top.node_registry import register_node, unregister_node, get_registered_nodes
+import psutil
 
 
 class TestROS2Utils(unittest.TestCase):
@@ -278,6 +279,89 @@ class TestRegistryStartTime(unittest.TestCase):
         # Should use psutil time as fallback
         self.assertEqual(start_time, psutil_start_time)
         mock_proc.create_time.assert_called_once()
+
+
+class TestKillProcess(unittest.TestCase):
+    """Test kill process functionality"""
+    
+    def setUp(self):
+        """Set up test environment"""
+        self.monitor = NodeMonitor()
+    
+    @patch('psutil.Process')
+    def test_kill_process_success(self, mock_process_class):
+        """Test successful process termination"""
+        # Mock a process
+        mock_proc = MagicMock()
+        mock_proc.terminate.return_value = None
+        mock_proc.wait.return_value = None
+        mock_process_class.return_value = mock_proc
+        
+        # Add process to monitor
+        self.monitor.processes["/test_node"] = mock_proc
+        
+        # Test kill
+        result = self.monitor.kill_process("/test_node", force=False)
+        
+        self.assertTrue(result)
+        mock_proc.terminate.assert_called_once()
+        mock_proc.wait.assert_called_once_with(timeout=1.0)
+    
+    @patch('psutil.Process')
+    def test_kill_process_force(self, mock_process_class):
+        """Test force kill with SIGKILL"""
+        # Mock a process
+        mock_proc = MagicMock()
+        mock_proc.kill.return_value = None
+        mock_proc.wait.return_value = None
+        mock_process_class.return_value = mock_proc
+        
+        # Add process to monitor
+        self.monitor.processes["/test_node"] = mock_proc
+        
+        # Test force kill
+        result = self.monitor.kill_process("/test_node", force=True)
+        
+        self.assertTrue(result)
+        mock_proc.kill.assert_called_once()
+        mock_proc.wait.assert_called_once_with(timeout=1.0)
+    
+    def test_kill_nonexistent_process(self):
+        """Test attempting to kill non-existent process"""
+        result = self.monitor.kill_process("/nonexistent_node")
+        self.assertFalse(result)
+    
+    @patch('psutil.Process')
+    def test_kill_process_no_such_process(self, mock_process_class):
+        """Test handling of NoSuchProcess exception"""
+        # Mock a process that raises NoSuchProcess
+        mock_proc = MagicMock()
+        mock_proc.terminate.side_effect = psutil.NoSuchProcess(1234)
+        mock_process_class.return_value = mock_proc
+        
+        # Add process to monitor
+        self.monitor.processes["/test_node"] = mock_proc
+        
+        # Test kill
+        result = self.monitor.kill_process("/test_node")
+        
+        self.assertFalse(result)
+    
+    @patch('psutil.Process')
+    def test_kill_process_access_denied(self, mock_process_class):
+        """Test handling of AccessDenied exception"""
+        # Mock a process that raises AccessDenied
+        mock_proc = MagicMock()
+        mock_proc.terminate.side_effect = psutil.AccessDenied(1234)
+        mock_process_class.return_value = mock_proc
+        
+        # Add process to monitor
+        self.monitor.processes["/test_node"] = mock_proc
+        
+        # Test kill
+        result = self.monitor.kill_process("/test_node")
+        
+        self.assertFalse(result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request introduces improvements to process monitoring and control in the `ros2top` tool, with a focus on more robust handling of nodes by PID, support for monitoring multiple nodes with the same name, and a new interactive process kill feature in the terminal UI.

**Process and Node Management Improvements:**

* Node monitoring now uses a unique key combining node name and PID (`"node_name:pid"`) to allow tracking multiple nodes with the same name.
* Added new internal functions `_remove_node_registration_by_pid` and `_update_node_heartbeat_by_pid` to safely update or remove node registrations based on PID.

**Process Control Feature:**

* Added a `kill_process` method to `NodeMonitor` that allows for terminating monitored processes by node name and/or PID, supporting both graceful and forced termination.
* The terminal UI now supports process selection, displays a kill confirmation dialog, and allows users to kill the selected process using keyboard shortcuts (`k`, `y`, `n`, `ESC`).