### PR TITLE
Account for composable nodes in UI

### DIFF
--- a/include/ros2top/ros2top.hpp
+++ b/include/ros2top/ros2top.hpp
@@ -188,8 +188,10 @@ public:
                 node_data["additional_info"] = additional_json;
             }
             
-            // Use node_name as key (same as Python format)
-            registry[normalized_name] = node_data;
+            // Key on PID + name, matching the Python format exactly. Node name
+            // alone is not unique: a component container hosts several nodes in
+            // one process, and they would overwrite each other.
+            registry[std::to_string(getpid()) + ":" + normalized_name] = node_data;
             
             return write_registry_json(registry);
             
@@ -224,8 +226,9 @@ public:
             std::string normalized_name = normalize_node_name(node_name);
             
             // Remove the node if it exists
-            if (registry.contains(normalized_name)) {
-                registry.erase(normalized_name);
+            std::string key = std::to_string(getpid()) + ":" + normalized_name;
+            if (registry.contains(key)) {
+                registry.erase(key);
                 write_registry_json(registry);
             }
             
@@ -257,8 +260,9 @@ public:
             std::string normalized_name = normalize_node_name(node_name);
             
             // Update heartbeat if node exists
-            if (registry.contains(normalized_name)) {
-                registry[normalized_name]["last_seen"] = std::time(nullptr);
+            std::string key = std::to_string(getpid()) + ":" + normalized_name;
+            if (registry.contains(key)) {
+                registry[key]["last_seen"] = std::time(nullptr);
                 write_registry_json(registry);
             }
             

--- a/ros2top/node_monitor.py
+++ b/ros2top/node_monitor.py
@@ -5,6 +5,7 @@ Core node monitoring functionality
 
 import time
 import psutil
+from collections import defaultdict
 from typing import Dict, List, Optional, NamedTuple, Tuple
 from .ros2_utils import is_ros2_available, get_ros2_nodes_with_pids, check_ros2_environment
 from .gpu_monitor import GPUMonitor
@@ -21,6 +22,10 @@ class NodeInfo(NamedTuple):
     gpu_utilization: float
     gpu_device_id: int
     start_time: float  # Unix timestamp
+    # How many monitored nodes live in this PID. >1 means composable nodes in a
+    # shared container: the cpu/ram/gpu figures above are whole-process values
+    # that cannot be split per node, and are identical for each of them.
+    shared_count: int = 1
 
 
 class NodeMonitor:
@@ -30,6 +35,10 @@ class NodeMonitor:
         self.refresh_interval = refresh_interval
         self.last_refresh = 0.0
         self.processes: Dict[str, psutil.Process] = {}
+        # One sampler per PID, so a process hosting N nodes is measured once.
+        # Keeping the same object across refreshes keeps cpu_percent()'s
+        # interval baseline fresh.
+        self._samplers: Dict[int, psutil.Process] = {}
         self.cores = psutil.cpu_count()
         self.gpu_monitor = GPUMonitor()
         
@@ -123,8 +132,9 @@ class NodeMonitor:
             if unique_key not in self.processes:
                 try:
                     proc = psutil.Process(pid)
-                    # Initialize CPU measurement
-                    proc.cpu_percent()
+                    # Start the CPU measurement interval now, not on first read,
+                    # otherwise the node's first displayed sample is always 0.0
+                    self._sampler(pid)
                     self.processes[unique_key] = proc
                 except psutil.NoSuchProcess:
                     pass
@@ -149,54 +159,116 @@ class NodeMonitor:
         Returns:
             List of NodeInfo objects
         """
+        # Composable nodes share one process, so group by PID and sample each
+        # process exactly once. Sampling per node would query psutil/NVML N
+        # times for the same PID and report that process's CPU, RAM and GPU
+        # memory N times over in any total.
+        nodes_by_pid: Dict[int, List[str]] = defaultdict(list)
+        for unique_key in self.processes:
+            node_name, _, pid = unique_key.rpartition(':')
+            nodes_by_pid[int(pid)].append(node_name)
+
+        self._prune_samplers(set(nodes_by_pid))
+
         node_infos = []
-        
-        for unique_key, process in self.processes.items():
+
+        for pid, node_names in nodes_by_pid.items():
             try:
-                # Extract original node name from unique key (format: "node_name:pid")
-                node_name = unique_key.rsplit(':', 1)[0]
-                
+                process = self._sampler(pid)
+
                 # Get CPU usage (normalized by number of cores)
                 raw_cpu = process.cpu_percent()
                 cpu_pct = raw_cpu / self.cores if self.cores > 0 else raw_cpu
-                
+
                 # Get RAM memory usage in MB
                 memory_info = process.memory_info()
                 ram_mb = memory_info.rss / (1024 * 1024)  # Resident Set Size in MB
-                
-                # Get process start time - prefer registry registration time
-                start_time = self._get_process_start_time(node_name, process)
-                
+
                 # Get GPU usage
-                gpu_mem, gpu_util, gpu_id = self.gpu_monitor.get_gpu_usage(process.pid)
-                
-                node_info = NodeInfo(
-                    name=node_name,
-                    pid=process.pid,
-                    cpu_percent=cpu_pct,
-                    ram_mb=ram_mb,
-                    gpu_memory_mb=gpu_mem,
-                    gpu_utilization=gpu_util,
-                    gpu_device_id=gpu_id,
-                    start_time=start_time
-                )
-                
-                node_infos.append(node_info)
-                
+                gpu_mem, gpu_util, gpu_id = self.gpu_monitor.get_gpu_usage(pid)
+
             except psutil.NoSuchProcess:
                 # Process died, will be cleaned up in next update
                 continue
             except Exception:
                 # Skip this process if we can't get info
                 continue
-        
+
+            # Every node in this process reports the same whole-process figures;
+            # shared_count tells the UI they must not be read as per-node.
+            for node_name in node_names:
+                node_infos.append(NodeInfo(
+                    name=node_name,
+                    pid=pid,
+                    cpu_percent=cpu_pct,
+                    ram_mb=ram_mb,
+                    gpu_memory_mb=gpu_mem,
+                    gpu_utilization=gpu_util,
+                    gpu_device_id=gpu_id,
+                    # Start time is per node: a composed node is loaded into an
+                    # already-running container, so it is younger than the process.
+                    start_time=self._get_process_start_time(node_name, process),
+                    shared_count=len(node_names),
+                ))
+
+        # Stable, process-grouped order. The UI selects and kills by row index
+        # into this list, so it must not sort independently or the row on screen
+        # and the node acted on would drift apart.
+        #
+        # Within a process the oldest node comes first: composable nodes are
+        # loaded into an already-running container, so the container's own node
+        # is always the eldest and belongs at the head of its group.
+        node_infos.sort(key=lambda n: (n.pid, n.start_time, n.name or ""))
         return node_infos
+
+    def _sampler(self, pid: int) -> psutil.Process:
+        """Get the cached psutil.Process used to measure this PID"""
+        process = self._samplers.get(pid)
+        if process is None:
+            process = psutil.Process(pid)
+            process.cpu_percent()  # prime the interval baseline
+            self._samplers[pid] = process
+        return process
+
+    def _prune_samplers(self, live_pids: set):
+        """Drop samplers for PIDs we no longer monitor"""
+        for pid in [p for p in self._samplers if p not in live_pids]:
+            del self._samplers[pid]
+
+    def get_process_totals(self, node_infos: Optional[List[NodeInfo]] = None
+                           ) -> Tuple[float, float, int]:
+        """
+        Aggregate CPU%, RAM MB and GPU MB across monitored processes.
+
+        Counts each PID once, so a container hosting N nodes contributes its
+        usage a single time rather than N times.
+
+        Pass the list from get_node_info_list() to total the numbers already on
+        screen; omitting it takes a fresh sample over a new, very short CPU
+        interval, which will not match the displayed rows.
+        """
+        if node_infos is None:
+            node_infos = self.get_node_info_list()
+
+        seen = set()
+        cpu = ram = 0.0
+        gpu = 0
+        for info in node_infos:
+            if info.pid in seen:
+                continue
+            seen.add(info.pid)
+            cpu += info.cpu_percent
+            ram += info.ram_mb
+            gpu += info.gpu_memory_mb
+        return cpu, ram, gpu
     
     def _get_process_start_time(self, node_name: str, process: psutil.Process) -> float:
-        """Get process start time, preferring registry registration time"""
+        """Get node start time, preferring registry registration time"""
         try:
-            # First try to get registration time from registry
-            registry_info = get_registered_node_info(node_name)
+            # First try to get registration time from registry. Pass the PID:
+            # two processes can host nodes of the same name, and a container's
+            # composed nodes each register at their own time.
+            registry_info = get_registered_node_info(node_name, process.pid)
             if registry_info and 'registration_time' in registry_info:
                 return registry_info['registration_time']
         except Exception:
@@ -273,6 +345,7 @@ class NodeMonitor:
     def shutdown(self):
         """Clean shutdown of monitoring"""
         self.processes.clear()
+        self._samplers.clear()
         self.gpu_monitor.shutdown()
     
     def get_system_info(self) -> Dict[str, str]:

--- a/ros2top/node_monitor.py
+++ b/ros2top/node_monitor.py
@@ -289,36 +289,40 @@ class NodeMonitor:
         """Force refresh of node list on next update"""
         self.last_refresh = 0.0
     
+    def _node_name_of(self, key: str) -> str:
+        """Node name held in a self.processes key, tolerating a missing ':pid'"""
+        name, sep, tail = key.rpartition(':')
+        return name if sep and tail.isdigit() else key
+
     def kill_process(self, node_name: str, pid: int = None, force: bool = False) -> bool:
         """
         Kill a monitored process
-        
+
+        Killing is per process, not per node: if the target shares its process
+        with composable nodes, they all die with it.
+
         Args:
             node_name: Name of the node/process to kill
-            pid: Specific PID to kill (optional, if not provided kills first match)
+            pid: PID to kill. Node names are not unique, so without this the
+                 first match wins, which may not be the node you meant.
             force: If True, use SIGKILL instead of SIGTERM
-            
+
         Returns:
             True if kill was successful, False otherwise
         """
-        # Find the process to kill
+        # Find the process to kill. Identity comes from the stored Process
+        # object, not from parsing the key, so it holds however the key was
+        # built.
         process_to_kill = None
-        key_to_remove = None
-        
-        if pid is not None:
-            # Look for specific node name and PID combination
-            unique_key = f"{node_name}:{pid}"
-            if unique_key in self.processes:
-                process_to_kill = self.processes[unique_key]
-                key_to_remove = unique_key
-        else:
-            # Find first process matching the node name
-            for key, process in self.processes.items():
-                if key.startswith(f"{node_name}:"):
-                    process_to_kill = process
-                    key_to_remove = key
-                    break
-        
+
+        for key, process in self.processes.items():
+            if self._node_name_of(key) != node_name:
+                continue
+            if pid is not None and process.pid != pid:
+                continue
+            process_to_kill = process
+            break
+
         if process_to_kill is None:
             return False
             
@@ -336,9 +340,16 @@ class NodeMonitor:
             except psutil.TimeoutExpired:
                 # Process didn't terminate within timeout
                 pass
-                
+
+            # The whole process is gone, so drop every node it was hosting,
+            # not just the one that was selected
+            dead_pid = process_to_kill.pid
+            for key in [k for k, p in self.processes.items() if p.pid == dead_pid]:
+                del self.processes[key]
+            self._samplers.pop(dead_pid, None)
+
             return True
-            
+
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             return False
     

--- a/ros2top/node_registry.py
+++ b/ros2top/node_registry.py
@@ -26,6 +26,34 @@ def _ensure_registry_dir():
     """Ensure the registry directory exists"""
     Path(REGISTRY_DIR).mkdir(parents=True, exist_ok=True)
 
+
+def _entry_key(pid, node_name: str) -> str:
+    """
+    Registry key for one node.
+
+    Keyed by PID *and* name because neither alone is unique: several nodes can
+    share one PID (composable nodes in a component container) and several
+    processes can run nodes of the same name.
+    """
+    return f"{pid}:{node_name}"
+
+
+def _entry_pid(key: str, data: Dict) -> Optional[int]:
+    """
+    PID of a registry entry, read from the entry rather than its key.
+
+    Older Python entries were keyed by bare PID and C++ entries by node name,
+    so the key format cannot be relied on. Every writer records 'pid' in the
+    entry itself, so read that and fall back to parsing the key.
+    """
+    pid = data.get('pid')
+    if pid is None:
+        pid = key.split(':', 1)[0]
+    try:
+        return int(pid)
+    except (TypeError, ValueError):
+        return None
+
 # Keep track of registered nodes for cleanup
 _registered_nodes = set()
 
@@ -144,10 +172,12 @@ def get_registered_nodes() -> List[Tuple[str, int]]:
         # Filter out stale registrations (only check if process is still running)
         active_nodes = []
         
-        for pid_str, data in nodes_data.items():
+        for key, data in nodes_data.items():
             # Check if process is still running
+            pid = _entry_pid(key, data)
+            if pid is None:
+                continue
             try:
-                pid = int(pid_str)
                 proc = psutil.Process(pid)
                 if proc.is_running():
                     # Process is running, include it regardless of heartbeat timing
@@ -165,13 +195,15 @@ def get_registered_nodes() -> List[Tuple[str, int]]:
         return []
 
 
-def get_registered_node_info(node_name: str) -> Optional[Dict]:
+def get_registered_node_info(node_name: str, pid: Optional[int] = None) -> Optional[Dict]:
     """
     Get detailed information about a registered node
-    
+
     Args:
         node_name: Name of the ROS2 node
-        
+        pid: PID hosting the node. Node names are not unique - the same name can
+             run in several processes - so pass this whenever it is known.
+
     Returns:
         Dictionary with node information or None if not found
     """
@@ -179,10 +211,17 @@ def get_registered_node_info(node_name: str) -> Optional[Dict]:
         # Normalize node name
         if not node_name.startswith('/'):
             node_name = f'/{node_name}'
-            
+
         nodes_data = _read_node_registrations()
-        return nodes_data.get(node_name)
-        
+        # Match on the recorded name, not the key: keys have varied between
+        # bare PID, bare node name and "pid:node_name" across versions.
+        for key, data in nodes_data.items():
+            if data.get('node_name') != node_name and key != node_name:
+                continue
+            if pid is None or _entry_pid(key, data) == pid:
+                return data
+        return None
+
     except Exception:
         return None
 
@@ -198,24 +237,25 @@ def cleanup_stale_registrations() -> int:
         nodes_data = _read_node_registrations()
         stale_nodes = []
         
-        for pid_str, data in nodes_data.items():
-            try:
-                pid = int(pid_str)
-                proc = psutil.Process(pid)
-                if not proc.is_running():
-                    stale_nodes.append(pid_str)
-            except (psutil.NoSuchProcess, ValueError):
-                stale_nodes.append(pid_str)
-                
-        # Remove stale nodes
-        for pid_str in stale_nodes:
-            try:
-                pid = int(pid_str)
-                _remove_node_registration_by_pid(pid)
-            except ValueError:
-                # Skip entries with invalid PID strings
+        for key, data in nodes_data.items():
+            pid = _entry_pid(key, data)
+            if pid is None:
+                stale_nodes.append((key, None))
                 continue
-            
+            try:
+                if not psutil.Process(pid).is_running():
+                    stale_nodes.append((key, pid))
+            except (psutil.NoSuchProcess, ValueError):
+                stale_nodes.append((key, pid))
+
+        # Remove stale nodes
+        for key, pid in stale_nodes:
+            if pid is None:
+                # Unparseable entry: drop it by key so it cannot linger forever
+                _remove_node_registration_by_key(key)
+            else:
+                _remove_node_registration_by_pid(pid)
+
         return len(stale_nodes)
         
     except Exception:
@@ -286,8 +326,9 @@ def _write_node_registration(node_data: Dict) -> bool:
                         # If JSON is corrupted, start fresh
                         existing_data = {}
             
-            # Update with new node data - use PID as key to allow multiple nodes with same name
-            existing_data[str(node_data['pid'])] = node_data
+            # Key on PID + name so a container hosting several composable nodes
+            # keeps one entry per node instead of overwriting itself
+            existing_data[_entry_key(node_data['pid'], node_data['node_name'])] = node_data
             
             # Write to temporary file first, then rename (atomic operation)
             temp_file = REGISTRATION_FILE + '.tmp'
@@ -352,10 +393,13 @@ def _remove_node_registration(node_name: str) -> bool:
                     # If JSON is corrupted, nothing to remove
                     return True
             
-            # Remove the node if it exists
-            if node_name in existing_data:
-                del existing_data[node_name]
-                
+            # Match on the recorded node name, not the key format
+            doomed = [k for k, d in existing_data.items()
+                      if d.get('node_name') == node_name or k == node_name]
+            if doomed:
+                for k in doomed:
+                    del existing_data[k]
+
                 # Write to temporary file first, then rename (atomic operation)
                 temp_file = REGISTRATION_FILE + '.tmp'
                 with open(temp_file, 'w') as f:
@@ -418,10 +462,13 @@ def _update_node_heartbeat(node_name: str) -> bool:
                     # If JSON is corrupted, can't update
                     return False
             
-            # Update heartbeat if node exists
-            if node_name in existing_data:
-                existing_data[node_name]['last_seen'] = time.time()
-                
+            # Match on the recorded node name, not the key format
+            touched = [k for k, d in existing_data.items()
+                       if d.get('node_name') == node_name or k == node_name]
+            if touched:
+                for k in touched:
+                    existing_data[k]['last_seen'] = time.time()
+
                 # Write to temporary file first, then rename (atomic operation)
                 temp_file = REGISTRATION_FILE + '.tmp'
                 with open(temp_file, 'w') as f:
@@ -450,9 +497,14 @@ def _update_node_heartbeat(node_name: str) -> bool:
         return False
 
 
-def _remove_node_registration_by_pid(pid: int) -> bool:
-    """Remove node registration by PID from file with file locking"""
-    
+def _remove_node_registration_by_key(key: str) -> bool:
+    """Remove one registry entry by its exact key"""
+    return _remove_node_registration_by_pid(None, key=key)
+
+
+def _remove_node_registration_by_pid(pid: Optional[int], key: str = None) -> bool:
+    """Remove node registrations by PID (or by exact key) with file locking"""
+
     try:
         if not os.path.exists(REGISTRATION_FILE):
             return True
@@ -485,11 +537,16 @@ def _remove_node_registration_by_pid(pid: int) -> bool:
                     # If JSON is corrupted, nothing to remove
                     return True
             
-            # Remove the node if it exists
-            pid_str = str(pid)
-            if pid_str in existing_data:
-                del existing_data[pid_str]
-                
+            # A dead PID takes every node it hosted with it, so remove them all
+            if key is not None:
+                doomed = [k for k in existing_data if k == key]
+            else:
+                doomed = [k for k, d in existing_data.items()
+                          if _entry_pid(k, d) == pid]
+            if doomed:
+                for k in doomed:
+                    del existing_data[k]
+
                 # Write to temporary file first, then rename (atomic operation)
                 temp_file = REGISTRATION_FILE + '.tmp'
                 with open(temp_file, 'w') as f:
@@ -552,11 +609,13 @@ def _update_node_heartbeat_by_pid(pid: int) -> bool:
                     # If JSON is corrupted, can't update
                     return False
             
-            # Update heartbeat if node exists
-            pid_str = str(pid)
-            if pid_str in existing_data:
-                existing_data[pid_str]['last_seen'] = time.time()
-                
+            # One heartbeat from a process refreshes every node it hosts
+            touched = [k for k, d in existing_data.items()
+                       if _entry_pid(k, d) == pid]
+            if touched:
+                for k in touched:
+                    existing_data[k]['last_seen'] = time.time()
+
                 # Write to temporary file first, then rename (atomic operation)
                 temp_file = REGISTRATION_FILE + '.tmp'
                 with open(temp_file, 'w') as f:

--- a/ros2top/ui/terminal_ui.py
+++ b/ros2top/ui/terminal_ui.py
@@ -46,7 +46,8 @@ class TerminalUI:
         self.show_kill_dialog = False
         self.kill_dialog_node = None
         self.kill_dialog_pid = None
-        
+        self.kill_dialog_shared = 1
+
         # Statistics
         self.stats = {
             'updates': 0,
@@ -491,28 +492,54 @@ class TerminalUI:
         available_width = self.table_section['width'] if hasattr(self, 'table_section') and self.table_section else 80
         node_name_width = max(20, available_width - fixed_columns_width - separators_width)
         
+        # get_node_info_list() already returns nodes grouped by PID, and the
+        # kill path selects by row index into that same list, so do not reorder
+        # here. Connectors are plain ASCII: the locale is never initialised for
+        # curses, so box-drawing characters would render as garbage.
+
         # Convert to table rows with specified columns:
         # PID, Uptime, %CPU, RAM(MB), GPU#, %GPU, GMEM(MB), Node Name
         rows = []
-        for node in nodes:
-            # Calculate uptime using the new formatting function
-            uptime = self._format_uptime(node.start_time)
-            
+        for idx, node in enumerate(nodes):
+            grouped = node.shared_count > 1
+            first_of_group = idx == 0 or nodes[idx - 1].pid != node.pid
+
+            # The group's first node is the process's own node (its container),
+            # so it heads the group unindented and owns the usage columns. The
+            # nodes composed into it hang off it.
+            if grouped and not first_of_group:
+                prefix = "  - "
+            else:
+                prefix = ""
+
             # Get node name - use full available width
             node_name = node.name if node.name else "unknown"
-            # Truncate to available width
-            if len(node_name) > node_name_width:
-                node_name = node_name[:node_name_width - 3] + "..."
-            
+            # A container's row says how many nodes it is hosting, so the group
+            # is still obvious when it scrolls past the top of the table
+            suffix = f"  (+{node.shared_count - 1} nodes)" if grouped and first_of_group else ""
+            # Truncate to available width, keeping connector and suffix intact
+            budget = node_name_width - len(prefix) - len(suffix)
+            if len(node_name) > budget:
+                node_name = node_name[:budget - 3] + "..."
+            node_name = prefix + node_name + suffix
+
+            # CPU/RAM/GPU belong to the process, not the node, so they appear
+            # once per group. Repeating them invites reading three nodes as
+            # three times the CPU. Uptime stays on every row: it is each node's
+            # own registration time, and a node composed into an already-running
+            # container is genuinely younger than the process hosting it.
+            show_usage = first_of_group
             row = [
-                str(node.pid),                    # PID
-                uptime,                          # Uptime
-                f"{node.cpu_percent:.1f}",       # %CPU
-                f"{node.ram_mb:.1f}",            # RAM(MB)
+                str(node.pid) if first_of_group else "",   # PID
+                self._format_uptime(node.start_time),      # Uptime
+                f"{node.cpu_percent:.1f}" if show_usage else "",   # %CPU
+                f"{node.ram_mb:.1f}" if show_usage else "",        # RAM(MB)
             ]
-            
+
             # Add GPU columns
-            if node.gpu_device_id >= 0:
+            if not show_usage:
+                row.extend(["", "", ""])
+            elif node.gpu_device_id >= 0:
                 row.extend([
                     str(node.gpu_device_id),           # GPU#
                     f"{node.gpu_utilization:.1f}",     # %GPU
@@ -520,11 +547,11 @@ class TerminalUI:
                 ])
             else:
                 row.extend(["--", "--", "--"])
-            
+
             row.append(node_name)                # Node Name
-            
+
             rows.append(row)
-        
+
         self.nodes_table.set_data(rows)
         
         # Sync selection state with table component
@@ -612,6 +639,16 @@ class TerminalUI:
             "  • Automatic node discovery via registry",
             "  • Color-coded usage indicators",
             "",
+            "Component Containers:",
+            "  -        - Nodes indented under a container run inside that",
+            "             same process. The container heads the group and",
+            "             carries the CPU/RAM/GPU, which are whole-process",
+            "             values that cannot be split per node.",
+            "             Uptime stays per node: a composed node is loaded",
+            "             into a running container, so it is the younger one.",
+            "             Killing any node in a group kills the whole",
+            "             process, and every node in it.",
+            "",
             "Color Legend:",
             "  Green    - Low usage (< 50%)",
             "  Yellow   - Medium usage (50-80%)",
@@ -680,6 +717,7 @@ class TerminalUI:
         selected_node = nodes[self.selected_row]
         self.kill_dialog_node = selected_node.name
         self.kill_dialog_pid = selected_node.pid
+        self.kill_dialog_shared = selected_node.shared_count
         self.show_kill_dialog = True
     
     def _confirm_kill(self):
@@ -697,6 +735,7 @@ class TerminalUI:
         self.show_kill_dialog = False
         self.kill_dialog_node = None
         self.kill_dialog_pid = None
+        self.kill_dialog_shared = 1
     
     def _draw_kill_dialog(self):
         """Draw kill confirmation dialog"""
@@ -708,7 +747,7 @@ class TerminalUI:
             
             # Dialog dimensions
             dialog_width = min(50, max_x - 4)
-            dialog_height = 8
+            dialog_height = 8 if self.kill_dialog_shared <= 1 else 9
             dialog_x = (max_x - dialog_width) // 2
             dialog_y = (max_y - dialog_height) // 2
             
@@ -722,13 +761,20 @@ class TerminalUI:
             pid_line = f"PID: {self.kill_dialog_pid}"
             warning = "This will terminate the selected process!"
             confirm_line = "Continue? (Y)es / (N)o / (ESC) Cancel"
-            
+
             # Center text in dialog
             self._addstr_with_color(dialog_y + 1, dialog_x + (dialog_width - len(title)) // 2, title, 4)
             self._addstr_with_color(dialog_y + 2, dialog_x + 2, node_line[:dialog_width-4], 0)
             self._addstr_with_color(dialog_y + 3, dialog_x + 2, pid_line[:dialog_width-4], 0)
             self._addstr_with_color(dialog_y + 4, dialog_x + 2, warning[:dialog_width-4], 3)
-            self._addstr_with_color(dialog_y + 6, dialog_x + 2, confirm_line[:dialog_width-4], 0)
+            row = dialog_y + 5
+            if self.kill_dialog_shared > 1:
+                # There is no way to kill one composed node: the signal goes to
+                # the process, taking all of its nodes down with it.
+                shared_line = f"Also kills {self.kill_dialog_shared - 1} other node(s) in this process!"
+                self._addstr_with_color(row, dialog_x + 2, shared_line[:dialog_width-4], 3)
+                row += 1
+            self._addstr_with_color(row + 1, dialog_x + 2, confirm_line[:dialog_width-4], 0)
             
         except curses.error:
             pass

--- a/tests/test_registry_keys.py
+++ b/tests/test_registry_keys.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""The registry must hold one entry per node, even when nodes share a PID."""
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import ros2top.node_registry as reg  # noqa: E402
+
+
+def _isolate():
+    d = tempfile.mkdtemp()
+    reg.REGISTRY_DIR = d
+    reg.REGISTRATION_FILE = os.path.join(d, 'nodes.json')
+    reg.LOCK_FILE = os.path.join(d, 'nodes.lock')
+    reg._registered_nodes.clear()
+
+
+def test_composable_nodes_all_survive():
+    """Three nodes registering from one process must not overwrite each other."""
+    _isolate()
+    for name in ('/talker', '/listener', '/my_container'):
+        assert reg.register_node(name), f'register {name}'
+
+    nodes = reg.get_registered_nodes()
+    assert len(nodes) == 3, f'expected 3 entries, got {nodes}'
+    assert {n for n, _ in nodes} == {'/talker', '/listener', '/my_container'}
+    assert {p for _, p in nodes} == {os.getpid()}, 'all three share this PID'
+    print('OK: 3 nodes on 1 PID all kept')
+
+
+def test_cpp_written_entries_are_visible():
+    """C++ keys by node name; entries must still be read, via their pid field."""
+    _isolate()
+    pid = os.getpid()
+    json.dump({
+        f'{pid}:/new_style': {'node_name': '/new_style', 'pid': pid},
+        '/cpp_legacy_key': {'node_name': '/cpp_legacy_key', 'pid': pid},
+        str(pid): {'node_name': '/py_legacy_key', 'pid': pid},
+    }, open(reg.REGISTRATION_FILE, 'w'))
+
+    names = {n for n, _ in reg.get_registered_nodes()}
+    assert names == {'/new_style', '/cpp_legacy_key', '/py_legacy_key'}, names
+    print('OK: new, C++-legacy and Python-legacy keys all visible')
+
+
+def test_dead_pid_removes_all_its_nodes():
+    _isolate()
+    dead = 999999  # not a running pid
+    json.dump({
+        f'{dead}:/a': {'node_name': '/a', 'pid': dead},
+        f'{dead}:/b': {'node_name': '/b', 'pid': dead},
+        f'{os.getpid()}:/alive': {'node_name': '/alive', 'pid': os.getpid()},
+    }, open(reg.REGISTRATION_FILE, 'w'))
+
+    assert not any(p == dead for _, p in reg.get_registered_nodes())
+    reg.cleanup_stale_registrations()
+    left = json.load(open(reg.REGISTRATION_FILE))
+    assert set(left) == {f'{os.getpid()}:/alive'}, left
+    print('OK: dead PID took both of its nodes with it')
+
+
+def test_unregister_and_heartbeat_by_name():
+    _isolate()
+    for name in ('/talker', '/listener'):
+        reg.register_node(name)
+
+    assert reg.heartbeat('/talker')
+    reg._remove_node_registration('/talker')
+    names = {n for n, _ in reg.get_registered_nodes()}
+    assert names == {'/listener'}, f'unregister hit the wrong nodes: {names}'
+    print('OK: unregister/heartbeat target one node, not the whole process')
+
+
+if __name__ == '__main__':
+    test_composable_nodes_all_survive()
+    test_cpp_written_entries_are_visible()
+    test_dead_pid_removes_all_its_nodes()
+    test_unregister_and_heartbeat_by_name()

--- a/tests/test_ros2top.py
+++ b/tests/test_ros2top.py
@@ -248,16 +248,18 @@ class TestRegistryStartTime(unittest.TestCase):
         
         # Mock psutil process
         mock_proc = MagicMock()
+        mock_proc.pid = 1234
         mock_proc.create_time.return_value = 1234567800.0  # Different time
         mock_process.return_value = mock_proc
-        
+
         # Create monitor and test start time retrieval
         monitor = NodeMonitor()
         start_time = monitor._get_process_start_time("/test_node", mock_proc)
-        
+
         # Should use registry time, not psutil time
         self.assertEqual(start_time, registry_start_time)
-        mock_get_info.assert_called_once_with("/test_node")
+        # PID is passed too: the same node name can run in several processes
+        mock_get_info.assert_called_once_with("/test_node", 1234)
     
     @patch('ros2top.node_monitor.get_registered_node_info')
     @patch('psutil.Process')

--- a/tests/test_shared_process.py
+++ b/tests/test_shared_process.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Nodes sharing one PID (composable nodes in a container) must be measured once."""
+
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from ros2top.node_monitor import NodeMonitor  # noqa: E402
+
+
+def _busy_process():
+    """A real child process that actually burns CPU, so cpu_percent() is non-zero."""
+    return subprocess.Popen(
+        [sys.executable, '-c', 'while True: pass'],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def test_shared_pid_measured_once():
+    container = _busy_process()
+    solo = _busy_process()
+    try:
+        monitor = NodeMonitor(refresh_interval=0.0)
+        # Three composable nodes in one container + one standalone node.
+        monitor._add_new_nodes_with_pids([
+            ('/talker', container.pid),
+            ('/listener', container.pid),
+            ('/my_container', container.pid),
+            ('/standalone', solo.pid),
+        ])
+
+        time.sleep(1.0)  # let cpu_percent() accumulate a real interval
+        infos = monitor.get_node_info_list()
+        by_name = {i.name: i for i in infos}
+
+        assert len(infos) == 4, f'expected one row per node, got {len(infos)}'
+
+        # every node still gets its own row
+        assert set(by_name) == {'/talker', '/listener', '/my_container', '/standalone'}
+
+        # the three container nodes are flagged as sharing a process
+        for name in ('/talker', '/listener', '/my_container'):
+            assert by_name[name].shared_count == 3, f'{name} shared_count'
+            assert by_name[name].pid == container.pid
+        assert by_name['/standalone'].shared_count == 1
+
+        # sampled once => the shared rows are byte-identical, not three
+        # independent (and differing) samples of the same process
+        shared = [by_name[n] for n in ('/talker', '/listener', '/my_container')]
+        assert len({i.cpu_percent for i in shared}) == 1, 'cpu differs across shared rows'
+        assert len({i.ram_mb for i in shared}) == 1, 'ram differs across shared rows'
+        assert shared[0].cpu_percent > 0, 'busy process should report cpu'
+
+        # one sampler per PID, not one per node
+        assert set(monitor._samplers) == {container.pid, solo.pid}, monitor._samplers
+
+        # totals count each process once instead of inflating by 3x
+        cpu, ram, _ = monitor.get_process_totals(infos)
+        naive_cpu = sum(i.cpu_percent for i in infos)
+        expected = by_name['/talker'].cpu_percent + by_name['/standalone'].cpu_percent
+        assert abs(cpu - expected) < 1e-9, f'total cpu {cpu} != {expected}'
+        assert naive_cpu > cpu, 'test is not exercising the inflation it guards'
+
+        naive_ram = sum(i.ram_mb for i in infos)
+        assert abs(ram - (by_name['/talker'].ram_mb
+                          + by_name['/standalone'].ram_mb)) < 1e-9
+        assert naive_ram > ram
+
+        # dead processes must not leak samplers
+        container.kill()
+        container.wait()
+        monitor.processes = {k: v for k, v in monitor.processes.items()
+                             if not k.endswith(f':{container.pid}')}
+        monitor.get_node_info_list()
+        assert set(monitor._samplers) == {solo.pid}, monitor._samplers
+
+        print('OK: shared-PID nodes sampled once, totals not inflated')
+    finally:
+        for p in (container, solo):
+            if p.poll() is None:
+                p.kill()
+            p.wait()
+
+
+if __name__ == '__main__':
+    test_shared_pid_measured_once()

--- a/tests/test_shared_process.py
+++ b/tests/test_shared_process.py
@@ -84,5 +84,65 @@ def test_shared_pid_measured_once():
             p.wait()
 
 
+def test_display_order_matches_kill_order():
+    """The UI kills by row index, so table order must equal get_node_info_list()."""
+    from unittest.mock import MagicMock
+    from ros2top.ui.terminal_ui import TerminalUI
+
+    container = _busy_process()
+    solo = _busy_process()
+    try:
+        monitor = NodeMonitor(refresh_interval=0.0)
+        monitor._add_new_nodes_with_pids([
+            ('/zzz_composed_later', container.pid),
+            ('/aaa_other_process', solo.pid),
+            ('/mmm_container', container.pid),
+        ])
+
+        # The container is the eldest node in its process; the composed node is
+        # loaded later. Names are chosen so alphabetical order would disagree.
+        now = time.time()
+        monitor._get_process_start_time = lambda name, proc: {
+            '/mmm_container': now - 100,
+            '/zzz_composed_later': now - 10,
+            '/aaa_other_process': now - 50,
+        }[name]
+
+        infos = monitor.get_node_info_list()
+
+        # grouped by pid, so same-process nodes are adjacent
+        pids = [i.pid for i in infos]
+        assert pids == sorted(pids), f'not grouped by pid: {pids}'
+
+        # the container heads its group despite sorting last alphabetically
+        group = [i.name for i in infos if i.pid == container.pid]
+        assert group[0] == '/mmm_container', f'container should head group: {group}'
+
+        ui = TerminalUI(monitor)
+        captured = {}
+        ui.nodes_table = MagicMock()
+        ui.nodes_table.set_data.side_effect = lambda r: captured.setdefault('rows', r)
+        ui.table_section = {'width': 100}
+        ui._update_nodes_table()
+
+        # last column is the node name, plus connector and/or count suffix
+        names = [r[-1].split('(+')[0].strip().lstrip('- ') for r in captured['rows']]
+        assert names == [i.name for i in infos], (
+            f'display order {names} != kill order {[i.name for i in infos]}')
+
+        # the container row announces the group; children hang off it
+        header = [r[-1] for r in captured['rows'] if '/mmm_container' in r[-1]][0]
+        assert header.startswith('/mmm_container') and '(+1 nodes)' in header, header
+        child = [r[-1] for r in captured['rows'] if '/zzz_composed_later' in r[-1]][0]
+        assert child.startswith('  - '), child
+        print('OK: container heads group, display order matches kill order')
+    finally:
+        for p in (container, solo):
+            if p.poll() is None:
+                p.kill()
+            p.wait()
+
+
 if __name__ == '__main__':
     test_shared_pid_measured_once()
+    test_display_order_matches_kill_order()

--- a/tests/test_shared_process.py
+++ b/tests/test_shared_process.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 import time
 
+import psutil
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from ros2top.node_monitor import NodeMonitor  # noqa: E402
@@ -143,6 +145,58 @@ def test_display_order_matches_kill_order():
             p.wait()
 
 
+def test_kill_removes_every_node_in_the_process():
+    """Killing one composed node kills the container, so all its nodes must go."""
+    container = _busy_process()
+    solo = _busy_process()
+    try:
+        monitor = NodeMonitor(refresh_interval=0.0)
+        monitor._add_new_nodes_with_pids([
+            ('/my_container', container.pid),
+            ('/talker', container.pid),
+            ('/listener', container.pid),
+            ('/talker', solo.pid),      # same name, different process
+        ])
+        monitor.get_node_info_list()  # populate samplers
+        assert len(monitor.processes) == 4
+        assert set(monitor._samplers) == {container.pid, solo.pid}
+
+        # naming a PID must pick that process, not the first same-named node
+        assert monitor.kill_process('/talker', pid=solo.pid, force=True)
+        assert container.poll() is None, 'killed the wrong process'
+        assert set(monitor._samplers) == {container.pid}, monitor._samplers
+        assert [monitor._node_name_of(k) for k in monitor.processes] == [
+            '/my_container', '/talker', '/listener']
+
+        # killing any node of the container takes all three with it
+        assert monitor.kill_process('/listener', pid=container.pid, force=True)
+        assert monitor.processes == {}, monitor.processes
+        assert monitor._samplers == {}, monitor._samplers
+        print('OK: kill removes every node of the process it ends')
+    finally:
+        for p in (container, solo):
+            if p.poll() is None:
+                p.kill()
+            p.wait()
+
+
+def test_kill_tolerates_key_without_pid_suffix():
+    """Keys are 'name:pid', but the API must not break if one lacks the suffix."""
+    proc = _busy_process()
+    try:
+        monitor = NodeMonitor(refresh_interval=0.0)
+        monitor.processes['/legacy_node'] = psutil.Process(proc.pid)
+        assert monitor.kill_process('/legacy_node', force=True)
+        assert monitor.processes == {}
+        print('OK: kill handles a key with no :pid suffix')
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait()
+
+
 if __name__ == '__main__':
     test_shared_pid_measured_once()
     test_display_order_matches_kill_order()
+    test_kill_removes_every_node_in_the_process()
+    test_kill_tolerates_key_without_pid_suffix()


### PR DESCRIPTION
A component container runs several ROS 2 nodes inside one process. ros2top assumed one node per PID throughout, which broke four separate things from the registry that stores nodes, to the numbers on screen, to the kill key.

### What changed
- Registry keyed by pid:node_name. Readers take the PID from the entry's own pid field rather than parsing the key, so entries from any previous version still load. C++ header writes the same format.
- Monitor groups by PID, samples each process once. NodeInfo.shared_count distinguishes whole-process figures from per-node ones; get_process_totals() counts each PID once.
- Kill resolves from the stored psutil.Process, then drops every node of the ended process plus its sampler.
- UI puts the container at the head of its group carrying the usage columns.