### PR TITLE
feat: Implement automatic node discovery and enhance monitoring capabilites

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A real-time monitor for ROS2 nodes showing CPU, RAM, and GPU usage - like `htop`
 - 🖥️ **Terminal-based interface** using curses
 - 🔄 **Auto-refresh** with configurable intervals
 - 🏷️ **Process tree awareness** (includes child processes)
+- 🛰️ **Automatic node discovery** from the ROS graph, with no code changes (on supported middleware)
+- 📦 **Component container aware** - composable nodes are grouped under the container hosting them
 - 📝 **Node registration API** for reliable node-to-monitor communication
 
 ## Installation
@@ -64,6 +66,7 @@ ros2top
 ```bash
 ros2top --help                # Show help
 ros2top --refresh 2          # Refresh every 2 seconds (default: 5)
+ros2top --no-auto-discovery  # Only show nodes that registered themselves
 ros2top --version           # Show version
 ```
 
@@ -124,9 +127,56 @@ ros2top --refresh 2
 
 ## How It Works
 
-1. **Node Registartion**: Every node registers its name and PID at startup with ros2top.
+1. **Node discovery**: ros2top finds nodes two ways - automatically from the ROS
+   graph, and from nodes that register themselves (see below).
 2. **Resource Monitoring**: Uses `psutil` for CPU/RAM and `pynvml` for GPU metrics.
 3. **Display**: Curses-based terminal interface for real-time updates.
+
+### Node discovery
+
+To show a node's resource usage, ros2top needs its **PID**, and the ROS graph
+does not publish that. Two mechanisms fill the gap:
+
+**Automatic (no code changes).** On middleware whose DDS GUID encodes the
+process id - Fast DDS, the ROS 2 default - ros2top recovers the node-to-PID
+mapping from the graph alone. Auto-discovered nodes are shown with a `~` prefix,
+because their PID is *inferred* rather than reported.
+
+**Registration (always works).** A node that calls `register_node()` states its
+PID directly. This is required on middleware that does not carry the PID, such
+as `rmw_zenoh_cpp` and Cyclone DDS, and it is more precise everywhere: registered
+nodes report their own start time and can attach custom metadata.
+
+The status bar shows the middleware in use and whether auto-discovery is
+working:
+
+```text
+ROS2✓ | RMW:fastrtps | Auto✓ | Nodes:4      # discovered automatically
+ROS2✓ | RMW:zenoh | Auto✗ register | Nodes:0  # registration required
+```
+
+If no nodes appear, ros2top explains why in the table area rather than showing
+an empty list. Use `--no-auto-discovery` to ignore the graph and show only
+registered nodes.
+
+### Composable nodes
+
+Nodes loaded into a component container all run in **one process**, so their
+CPU, RAM and GPU usage cannot be separated - the numbers belong to the process,
+not to any one node. ros2top shows the container heading its group with the
+usage figures listed once, and the nodes it hosts indented beneath it:
+
+```text
+PID      Uptime  %CPU  RAM(MB)  GPU#  %GPU  GMEM(MB)  Node Name
+3744993  10s     0.0   30.1     --    --    --        /my_container  (+2 nodes)
+         06s                                            - /talker
+         02s                                            - /listener
+3742958  02s     0.0   27.0     --    --    --        /standalone_talker
+```
+
+Uptime stays per node, since a node composed into an already-running container
+is younger than the process hosting it. Killing any node in a group ends the
+whole process, taking every node in it - the kill dialog warns before it does.
 
 ## Troubleshooting
 
@@ -137,9 +187,18 @@ ros2top --refresh 2
 
 ### Nodes not showing up
 
-- Verify nodes are running: `ros2 node list`
-- Check node info: `ros2 node info /your_node`
-- Some nodes might not have detectable PIDs
+First check the status bar. It names the middleware in use and whether
+auto-discovery is working.
+
+- `Auto✗ register` - your middleware does not expose node PIDs (Zenoh, Cyclone).
+  Nodes **must** call `register_node()` to appear. See the
+  [Python](examples/python/README.md) and [C++](examples/cpp/README.md) examples.
+- `Auto✓` but a node is missing - verify it is running with `ros2 node list`.
+  Nodes on other machines are skipped on purpose: their PID is meaningless
+  locally. A node is also skipped when its PID cannot be pinned down
+  unambiguously, since showing the wrong process is worse than showing none.
+- No status at all / `rclpy is not importable` - ROS 2 is not sourced, so the
+  graph cannot be read. Source your installation, or use registration.
 
 ## Development
 
@@ -174,6 +233,7 @@ ros2top/
 │   ├── main.py             # CLI entry point
 │   ├── node_monitor.py     # Core monitoring logic
 │   ├── node_registry.py    # Node registration system
+│   ├── graph_discovery.py  # Automatic node discovery from the ROS graph
 │   ├── gpu_monitor.py      # GPU monitoring
 │   ├── ros2_utils.py       # ROS2 utilities
 │   └── ui/                 # User interface components

--- a/ros2top/graph_discovery.py
+++ b/ros2top/graph_discovery.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""
+Registry-free node discovery from the ROS 2 graph.
+
+Nodes that never call ros2top.register_node() are invisible to the registry.
+On some middleware they can still be found: the DDS GUID that every endpoint
+carries encodes the PID of the process that owns it, so the graph alone is
+enough to map a node name to a process.
+
+This is a property of the *middleware*, not of ROS 2. Fast DDS lays its GUID
+prefix out as:
+
+    [0:2]  vendor id (01 0f = eProsima)
+    [2:4]  host id
+    [4:6]  low 16 bits of the PID, little-endian
+    [6:8]  random
+    [8:12] participant counter
+
+Zenoh and Cyclone use different schemes and carry no PID, so discovery is
+unavailable there and nodes must register themselves. Rather than keep a list
+of which vendors work -- which would rot the moment any of them changes its
+layout -- we simply ask the graph where *our own* node lives and check whether
+the answer is our PID. That proves the capability instead of assuming it.
+"""
+
+import atexit
+import os
+import threading
+import time
+from collections import defaultdict
+from enum import Enum
+from typing import Dict, Iterable, List, NamedTuple, Optional, Sequence, Set, Tuple
+
+# Our own graph node is named with this prefix, so instances of ros2top can
+# recognise and skip each other rather than reporting themselves as user nodes.
+_NODE_PREFIX = 'ros2top_discovery_'
+
+# rmw_dds_common reports these placeholders for an endpoint whose owning node it
+# has not matched yet. They are not node names: taken literally they show up as
+# a phantom "_NODE_NAME_UNKNOWN_" row for a second until discovery settles.
+_UNKNOWN_NAME = '_NODE_NAME_UNKNOWN_'
+_UNKNOWN_NAMESPACE = '_NODE_NAMESPACE_UNKNOWN_'
+
+# Byte ranges within the 12-byte GUID prefix
+_HOST = slice(2, 4)
+_PID = slice(4, 6)
+
+
+class DiscoveryMode(Enum):
+    AUTO = 'auto'       # the graph gives us node -> PID, no registration needed
+    MANUAL = 'manual'   # nodes must register themselves to be seen
+
+
+class DiscoveryStatus(NamedTuple):
+    mode: DiscoveryMode
+    rmw: str        # middleware identifier, e.g. 'rmw_fastrtps_cpp'
+    reason: str     # human-readable, shown in the UI when mode is MANUAL
+
+    @property
+    def is_auto(self) -> bool:
+        return self.mode is DiscoveryMode.AUTO
+
+    @property
+    def short_rmw(self) -> str:
+        """'rmw_fastrtps_cpp' -> 'fastrtps', for the status bar"""
+        name = self.rmw
+        if name.startswith('rmw_'):
+            name = name[4:]
+        if name.endswith('_cpp'):
+            name = name[:-4]
+        return name or 'unknown'
+
+
+# --------------------------------------------------------------------------
+# Pure helpers. No ROS, no /proc, so they can be unit tested anywhere.
+# --------------------------------------------------------------------------
+
+def pid_low16(prefix: Sequence[int]) -> int:
+    """The 16 PID bits a Fast DDS GUID prefix carries"""
+    return int.from_bytes(bytes(prefix)[_PID], 'little')
+
+
+def host_id(prefix: Sequence[int]) -> bytes:
+    """The host portion of a GUID prefix"""
+    return bytes(prefix)[_HOST]
+
+
+def carries_own_pid(prefix: Sequence[int], pid: Optional[int] = None) -> bool:
+    """Self-test: does this prefix encode the PID we are actually running as?"""
+    if pid is None:
+        pid = os.getpid()
+    return pid_low16(prefix) == pid & 0xFFFF
+
+
+def resolve(nodes_by_prefix: Dict[bytes, Set[str]],
+            local_pids: Iterable[int],
+            own_host: bytes) -> List[Tuple[str, int]]:
+    """
+    Map node names to PIDs.
+
+    Args:
+        nodes_by_prefix: GUID prefix -> node names sharing it. One prefix is one
+            participant, i.e. one process, so a component container and every
+            node composed into it appear under a single key.
+        local_pids: PIDs of ROS processes on this machine.
+        own_host: host id of the machine we are running on.
+
+    Returns:
+        (node_name, pid) pairs. Nodes that cannot be resolved *unambiguously*
+        are omitted rather than guessed at.
+    """
+    by_low16 = defaultdict(list)
+    for pid in local_pids:
+        by_low16[pid & 0xFFFF].append(pid)
+
+    resolved = []
+    for prefix, names in nodes_by_prefix.items():
+        # A node on another machine would have a meaningless PID here: its low
+        # 16 bits could collide with a local process and we would happily show
+        # somebody else's CPU usage against it.
+        if host_id(prefix) != own_host:
+            continue
+
+        # Only 16 bits of PID are available, so collisions are real. Narrowing
+        # to ROS processes makes them rare, but when one does happen there is
+        # no way to tell the candidates apart -- so report nothing.
+        candidates = by_low16.get(pid_low16(prefix), ())
+        if len(candidates) != 1:
+            continue
+
+        for name in names:
+            resolved.append((name, candidates[0]))
+
+    return resolved
+
+
+# --------------------------------------------------------------------------
+# Local process enumeration
+# --------------------------------------------------------------------------
+
+def is_ros_process(pid: int) -> bool:
+    """Whether a local process has the ROS client library mapped in"""
+    try:
+        with open(f'/proc/{pid}/maps') as f:
+            return 'librcl.so' in f.read()
+    except PermissionError:
+        # /proc/<pid>/maps is ptrace-protected, so a node running as another
+        # user (root is common on robots) is unreadable. cmdline is world
+        # readable, so fall back to it rather than dropping the process.
+        try:
+            with open(f'/proc/{pid}/cmdline', 'rb') as f:
+                return b'/opt/ros/' in f.read()
+        except OSError:
+            return False
+    except OSError:
+        return False
+
+
+def _is_reportable(node_name: str, node_namespace: str) -> bool:
+    """Whether a graph endpoint belongs to a node worth showing the user"""
+    if node_name == _UNKNOWN_NAME or node_namespace == _UNKNOWN_NAMESPACE:
+        return False        # discovery has not matched this endpoint yet
+    if node_name.startswith('_ros2cli_daemon_'):
+        return False        # ros2cli's own helper, not a user's node
+    if node_name.startswith(_NODE_PREFIX):
+        return False        # another ros2top's discovery node
+    return True
+
+
+def local_ros_pids() -> Set[int]:
+    """PIDs of every ROS process on this machine"""
+    pids = set()
+    for entry in os.listdir('/proc'):
+        if entry.isdigit() and is_ros_process(int(entry)):
+            pids.add(int(entry))
+    return pids
+
+
+# --------------------------------------------------------------------------
+# The graph client
+# --------------------------------------------------------------------------
+
+class GraphDiscovery:
+    """
+    Watches the ROS graph on a background thread and caches node -> PID.
+
+    A single node is created for the lifetime of the process. NodeMonitor
+    refreshes as often as every 0.1s, which is far too fast to stand up an
+    rclpy node each time, so callers read a cached snapshot instead.
+    """
+
+    def __init__(self, period: float = 1.0, autostart: bool = True):
+        self._period = period
+        self._lock = threading.Lock()
+        self._nodes: List[Tuple[str, int]] = []
+        self._status = DiscoveryStatus(
+            DiscoveryMode.MANUAL, 'unknown', 'discovery has not started yet')
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._context = None
+        self._node = None
+        self._own_host: Optional[bytes] = None
+
+        if autostart:
+            self.start()
+
+    # -- public API --------------------------------------------------------
+
+    @property
+    def status(self) -> DiscoveryStatus:
+        with self._lock:
+            return self._status
+
+    def get_nodes_with_pids(self) -> List[Tuple[str, int]]:
+        """Latest snapshot. Empty unless discovery is working."""
+        with self._lock:
+            return list(self._nodes)
+
+    def start(self):
+        # Importing rclpy costs over a second, so it happens on the worker.
+        # Doing it here would add that to every ros2top startup, including
+        # the runs where ROS is not even installed.
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(target=self._run, daemon=True,
+                                        name='ros2top-discovery')
+        self._thread.start()
+        # A daemon thread killed mid-spin leaves rclpy's C++ side to abort with
+        # "terminate called without an active exception" on the way out. Stop
+        # it properly even when the caller forgets to.
+        atexit.register(self.shutdown)
+
+    def shutdown(self):
+        """Stop the discovery thread. Safe to call more than once."""
+        self._stop.set()
+        thread, self._thread = self._thread, None
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=2.0)
+
+    # -- internals ---------------------------------------------------------
+
+    def _set_status(self, mode: DiscoveryMode, rmw: str, reason: str):
+        with self._lock:
+            self._status = DiscoveryStatus(mode, rmw, reason)
+
+    def _run(self):
+        try:
+            import rclpy
+            from rclpy.executors import SingleThreadedExecutor
+        except ImportError:
+            self._set_status(DiscoveryMode.MANUAL, 'unknown',
+                             'rclpy is not importable, so the ROS graph cannot '
+                             'be read. Source your ROS 2 installation, or '
+                             'register nodes with ros2top explicitly.')
+            return
+
+        rmw = 'unknown'
+        try:
+            from rclpy.utilities import get_rmw_implementation_identifier
+            # Own context, so ros2top never disturbs a global rclpy.init() if
+            # it is ever imported from inside a running node.
+            self._context = rclpy.Context()
+            rclpy.init(context=self._context)
+            rmw = get_rmw_implementation_identifier() or 'unknown'
+            self._node = rclpy.create_node(
+                f'{_NODE_PREFIX}{os.getpid()}', context=self._context)
+            executor = SingleThreadedExecutor(context=self._context)
+            executor.add_node(self._node)
+        except Exception as e:
+            self._set_status(DiscoveryMode.MANUAL, rmw,
+                             f'could not join the ROS graph: {e}')
+            self._cleanup_ros()
+            return
+
+        try:
+            next_snapshot = 0.0
+            while not self._stop.is_set():
+                executor.spin_once(timeout_sec=0.1)
+                now = time.monotonic()
+                if now >= next_snapshot:
+                    try:
+                        self._snapshot(rmw)
+                    except Exception:
+                        # A transient graph error must not kill the thread
+                        pass
+                    next_snapshot = now + self._period
+        finally:
+            self._cleanup_ros()
+
+    def _cleanup_ros(self):
+        try:
+            if self._node is not None:
+                self._node.destroy_node()
+        except Exception:
+            pass
+        try:
+            if self._context is not None:
+                import rclpy
+                rclpy.shutdown(context=self._context)
+        except Exception:
+            pass
+        self._node = None
+        self._context = None
+
+    def _collect_endpoints(self):
+        """-> (nodes_by_prefix, our own prefix or None)"""
+        node = self._node
+        by_prefix = defaultdict(set)
+        own_prefix = None
+        own_name = node.get_name()
+
+        for topic, _ in node.get_topic_names_and_types():
+            for getter in (node.get_publishers_info_by_topic,
+                           node.get_subscriptions_info_by_topic):
+                try:
+                    endpoints = getter(topic)
+                except Exception:
+                    continue
+                for info in endpoints:
+                    prefix = bytes(info.endpoint_gid[:12])
+                    if info.node_name == own_name:
+                        own_prefix = prefix
+                        continue  # never report ourselves
+                    if _is_reportable(info.node_name, info.node_namespace):
+                        namespace = info.node_namespace.rstrip('/')
+                        by_prefix[prefix].add(f'{namespace}/{info.node_name}')
+
+        return by_prefix, own_prefix
+
+    def _snapshot(self, rmw: str):
+        by_prefix, own_prefix = self._collect_endpoints()
+
+        if own_prefix is None:
+            # Discovery has not settled yet; say nothing rather than claim the
+            # middleware is unsupported.
+            return
+
+        if not carries_own_pid(own_prefix):
+            self._set_status(
+                DiscoveryMode.MANUAL, rmw,
+                f'{rmw} does not expose node PIDs, so nodes cannot be found '
+                f'automatically. They must register with ros2top to appear.')
+            with self._lock:
+                self._nodes = []
+            return
+
+        self._own_host = host_id(own_prefix)
+        resolved = resolve(by_prefix, local_ros_pids(), self._own_host)
+
+        self._set_status(DiscoveryMode.AUTO, rmw,
+                         'nodes are discovered from the ROS graph')
+        with self._lock:
+            self._nodes = resolved

--- a/ros2top/main.py
+++ b/ros2top/main.py
@@ -19,6 +19,7 @@ def create_argument_parser():
 Examples:
     ros2top                    # Run with default settings
     ros2top --refresh 2        # Refresh every 2 seconds
+    ros2top --no-auto-discovery  # Only registered nodes
 
     Controls:
     q/Q - Quit
@@ -35,11 +36,18 @@ Examples:
     )
     
     parser.add_argument(
+        '--no-auto-discovery',
+        action='store_true',
+        help='Only show nodes that registered with ros2top, never those found '
+             'on the ROS graph'
+    )
+
+    parser.add_argument(
         '--version', '-v',
         action='version',
         version=f'%(prog)s {__version__}'
     )
-    
+
     return parser
 
 
@@ -76,7 +84,8 @@ def main():
     
     # Create node monitor
     try:
-        monitor = NodeMonitor(refresh_interval=args.refresh)
+        monitor = NodeMonitor(refresh_interval=args.refresh,
+                              auto_discovery=not args.no_auto_discovery)
     except Exception as e:
         show_error_message(f"Failed to initialize node monitor: {e}")
         sys.exit(1)

--- a/ros2top/node_monitor.py
+++ b/ros2top/node_monitor.py
@@ -7,8 +7,9 @@ import time
 import psutil
 from collections import defaultdict
 from typing import Dict, List, Optional, NamedTuple, Tuple
-from .ros2_utils import is_ros2_available, get_ros2_nodes_with_pids, check_ros2_environment
+from .ros2_utils import is_ros2_available, check_ros2_environment
 from .gpu_monitor import GPUMonitor
+from .graph_discovery import DiscoveryMode, DiscoveryStatus, GraphDiscovery
 from .node_registry import get_registered_nodes, get_registered_node_info
 
 
@@ -26,19 +27,28 @@ class NodeInfo(NamedTuple):
     # shared container: the cpu/ram/gpu figures above are whole-process values
     # that cannot be split per node, and are identical for each of them.
     shared_count: int = 1
+    # True when the node was found on the ROS graph rather than registering
+    # itself. Its PID was inferred from the DDS GUID, so it is a weaker claim
+    # than a registration and worth showing as such.
+    auto_discovered: bool = False
 
 
 class NodeMonitor:
     """Monitor registered processes and their resource usage (supports both ROS2 nodes and generic processes)"""
     
-    def __init__(self, refresh_interval: float = 5.0):
+    def __init__(self, refresh_interval: float = 5.0, auto_discovery: bool = True):
         self.refresh_interval = refresh_interval
         self.last_refresh = 0.0
         self.processes: Dict[str, psutil.Process] = {}
+        # Node names found on the graph rather than in the registry
+        self._auto_names: set = set()
+        self.discovery = GraphDiscovery() if auto_discovery else None
         # One sampler per PID, so a process hosting N nodes is measured once.
         # Keeping the same object across refreshes keeps cpu_percent()'s
         # interval baseline fresh.
         self._samplers: Dict[int, psutil.Process] = {}
+        # Command line per PID, cached alongside the samplers
+        self._cmdlines: Dict[int, str] = {}
         self.cores = psutil.cpu_count()
         self.gpu_monitor = GPUMonitor()
         
@@ -47,7 +57,8 @@ class NodeMonitor:
     
     def cleanup(self):
         """Cleanup resources"""
-        pass
+        if self.discovery is not None:
+            self.discovery.shutdown()
         
     def is_ros2_available(self) -> bool:
         """Check if ROS2 is available"""
@@ -89,29 +100,42 @@ class NodeMonitor:
             return False
     
     def _get_all_processes_to_monitor(self) -> List[Tuple[str, int]]:
-        """Get all processes to monitor (primarily from registry, optionally including ROS2 nodes)"""
+        """Get all processes to monitor, from the registry plus the ROS graph"""
         all_processes = []
-        
-        # Primary source: registered processes
+
+        # Primary source: nodes that registered themselves. These are
+        # authoritative -- they carry a real registration time and any custom
+        # metadata -- so they win over anything the graph infers.
         try:
-            registered_nodes = get_registered_nodes()
-            all_processes.extend(registered_nodes)
+            all_processes.extend(get_registered_nodes())
         except Exception:
             pass
-        
-        # Secondary source: ROS2 nodes (if available and not already in registry)
-        if self.ros2_available:
+
+        # Secondary source: the ROS graph, for nodes that never registered.
+        # Their PID is inferred from the DDS GUID, so track which ones came
+        # from here in order to mark them in the UI.
+        auto_names = set()
+        if self.discovery is not None:
             try:
-                ros2_nodes = get_ros2_nodes_with_pids()
-                # Only add ROS2 nodes that aren't already registered
-                registered_names = {name for name, pid in all_processes}
-                for name, pid in ros2_nodes:
-                    if name not in registered_names:
+                known = set(all_processes)
+                for name, pid in self.discovery.get_nodes_with_pids():
+                    if (name, pid) not in known:
                         all_processes.append((name, pid))
+                        auto_names.add((name, pid))
             except Exception:
                 pass
-            
+        self._auto_names = auto_names
+
         return all_processes
+
+    def get_discovery_status(self) -> DiscoveryStatus:
+        """How nodes are being found, for the UI to report"""
+        if self.discovery is None:
+            return DiscoveryStatus(
+                DiscoveryMode.MANUAL, 'disabled',
+                'auto-discovery is off (--no-auto-discovery). Nodes must '
+                'register with ros2top to appear.')
+        return self.discovery.status
     
     def _remove_dead_nodes(self, current_nodes: List[str]):
         """Remove processes for nodes that no longer exist"""
@@ -209,6 +233,7 @@ class NodeMonitor:
                     # already-running container, so it is younger than the process.
                     start_time=self._get_process_start_time(node_name, process),
                     shared_count=len(node_names),
+                    auto_discovered=(node_name, pid) in self._auto_names,
                 ))
 
         # Stable, process-grouped order. The UI selects and kills by row index
@@ -218,8 +243,30 @@ class NodeMonitor:
         # Within a process the oldest node comes first: composable nodes are
         # loaded into an already-running container, so the container's own node
         # is always the eldest and belongs at the head of its group.
-        node_infos.sort(key=lambda n: (n.pid, n.start_time, n.name or ""))
+        #
+        # That only works when each node has its own registration time.
+        # Auto-discovered nodes do not, so they all share the process create
+        # time and would fall back to alphabetical order, burying the
+        # container mid-group. Naming the process's own node in its command
+        # line breaks the tie first.
+        node_infos.sort(key=lambda n: (n.pid,
+                                       not self._named_in_cmdline(n.pid, n.name),
+                                       n.start_time,
+                                       n.name or ""))
         return node_infos
+
+    def _named_in_cmdline(self, pid: int, node_name: Optional[str]) -> bool:
+        """Whether a process's command line names this node (e.g. -r __node:=x)"""
+        if not node_name:
+            return False
+        cmdline = self._cmdlines.get(pid)
+        if cmdline is None:
+            try:
+                cmdline = ' '.join(self._samplers[pid].cmdline())
+            except Exception:
+                cmdline = ''
+            self._cmdlines[pid] = cmdline
+        return node_name.lstrip('/') in cmdline
 
     def _sampler(self, pid: int) -> psutil.Process:
         """Get the cached psutil.Process used to measure this PID"""
@@ -234,6 +281,7 @@ class NodeMonitor:
         """Drop samplers for PIDs we no longer monitor"""
         for pid in [p for p in self._samplers if p not in live_pids]:
             del self._samplers[pid]
+            self._cmdlines.pop(pid, None)
 
     def get_process_totals(self, node_infos: Optional[List[NodeInfo]] = None
                            ) -> Tuple[float, float, int]:
@@ -357,6 +405,8 @@ class NodeMonitor:
         """Clean shutdown of monitoring"""
         self.processes.clear()
         self._samplers.clear()
+        if self.discovery is not None:
+            self.discovery.shutdown()
         self.gpu_monitor.shutdown()
     
     def get_system_info(self) -> Dict[str, str]:

--- a/ros2top/ros2_utils.py
+++ b/ros2top/ros2_utils.py
@@ -3,21 +3,17 @@
 Simplified ROS2 utilities using node registry as primary source
 """
 
-import subprocess
+import shutil
 from typing import List, Tuple, Optional, Dict
 from .node_registry import get_registered_nodes, cleanup_stale_registrations
 
 
 def is_ros2_available() -> bool:
     """Check if ROS2 is available in the environment"""
-    try:
-        result = subprocess.run(['ros2', '--help'], 
-                              capture_output=True, 
-                              text=True, 
-                              timeout=5)
-        return result.returncode == 0
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return False
+    # Looking the executable up on PATH rather than running `ros2 --help`:
+    # launching it costs over a second, which was being paid on every ros2top
+    # startup just to decide whether to print a tick in the status bar.
+    return shutil.which('ros2') is not None
 
 
 def get_ros2_nodes() -> List[str]:
@@ -63,11 +59,13 @@ def check_ros2_environment() -> Dict[str, str]:
     
     env_info = {}
     
-    # Check key ROS2 environment variables
+    # Check key ROS2 environment variables. RMW_IMPLEMENTATION is deliberately
+    # absent: it is unset whenever the default middleware is in use, which is
+    # the common case, so reading it here reports "Not set" and tells nobody
+    # anything. GraphDiscovery asks the middleware itself instead.
     ros_vars = [
         'ROS_DOMAIN_ID',
-        'ROS_LOCALHOST_ONLY', 
-        'RMW_IMPLEMENTATION',
+        'ROS_LOCALHOST_ONLY',
         'ROS_DISTRO'
     ]
     

--- a/ros2top/ui/components.py
+++ b/ros2top/ui/components.py
@@ -211,7 +211,11 @@ class Table(UIComponent):
         self.sort_column = 0
         self.sort_ascending = True
         self.selectable = True
-        
+        # Lines shown in place of the data rows when there are none. Without
+        # this an empty table is just a header, which tells the user nothing
+        # about why their nodes are missing.
+        self.empty_message: List[str] = []
+
         self._calculate_column_widths()
     
     def _calculate_column_widths(self):
@@ -339,10 +343,21 @@ class Table(UIComponent):
                 stdscr.addstr(current_row, self.rect.x, separator[:self.rect.width])
                 current_row += 1
             
+            # Nothing to list: explain why rather than leaving a bare header
+            if not self.rows and self.empty_message:
+                for line in self.empty_message:
+                    if current_row >= self.rect.bottom:
+                        break
+                    stdscr.addstr(current_row, self.rect.x + 2,
+                                  line[:max(0, self.rect.width - 3)])
+                    current_row += 1
+                self.dirty = False
+                return
+
             # Draw data rows
             visible_rows = self.rect.height - 2  # header + separator
             end_row = min(len(self.rows), self.scroll_offset + visible_rows)
-            
+
             for i in range(self.scroll_offset, end_row):
                 if current_row >= self.rect.bottom:
                     break

--- a/ros2top/ui/terminal_ui.py
+++ b/ros2top/ui/terminal_ui.py
@@ -16,6 +16,12 @@ from .components import (
 from .layout import LayoutManager, ResponsiveLayout
 
 
+def _wrap(text: str, width: int) -> List[str]:
+    """Wrap a status reason onto the table area"""
+    import textwrap
+    return textwrap.wrap(text, width) or [""]
+
+
 class TerminalUI:
     """Enhanced terminal interface with responsive design"""
     
@@ -412,7 +418,15 @@ class TerminalUI:
             if section['height'] > 1:
                 ros2_status = "ROS2✓" if self.monitor.is_ros2_available() else "ROS2✗"
                 node_count = self.monitor.get_nodes_count()
-                status_info = f"{ros2_status} | Nodes:{node_count} | +/-:Speed | Space:Update"
+                # Name the middleware and whether it lets us find nodes on our
+                # own, so "no nodes" is never a mystery
+                discovery = self.monitor.get_discovery_status()
+                auto = "Auto✓" if discovery.is_auto else "Auto✗ register"
+                # Only claim to know the middleware when we actually asked it
+                rmw = (f"RMW:{discovery.short_rmw} | "
+                       if discovery.short_rmw not in ('disabled', 'unknown') else "")
+                status_info = (f"{ros2_status} | {rmw}{auto} "
+                               f"| Nodes:{node_count} | +/-:Speed | Space:Update")
                 self._addstr_with_color(section['start_y'] + 1, 0, status_info[:section['width']], 4)
                 
         except curses.error:
@@ -478,6 +492,29 @@ class TerminalUI:
         except curses.error:
             pass
     
+    def _empty_table_message(self) -> List[str]:
+        """Explain an empty table, since 'no nodes' has several causes"""
+        status = self.monitor.get_discovery_status()
+        if status.is_auto:
+            return [
+                "",
+                "No ROS 2 nodes are running.",
+                "",
+                f"Nodes are being discovered automatically via {status.short_rmw}.",
+            ]
+
+        return [
+            "",
+            "No nodes found.",
+            "",
+        ] + [f"  {line}" for line in _wrap(status.reason, 66)] + [
+            "",
+            "  Register nodes to make them visible:",
+            "",
+            '    C++     ros2top::register_node("/my_node");',
+            "    Python  ros2top.register_node('/my_node')",
+        ]
+
     def _update_nodes_table(self):
         """Update nodes table data with specified format"""
         if not self.nodes_table:
@@ -512,8 +549,12 @@ class TerminalUI:
             else:
                 prefix = ""
 
-            # Get node name - use full available width
+            # Get node name - use full available width. Auto-discovered nodes
+            # are marked: their PID was inferred from the DDS GUID rather than
+            # reported by the node itself, which is a weaker claim.
             node_name = node.name if node.name else "unknown"
+            if node.auto_discovered:
+                node_name = f"~{node_name}"
             # A container's row says how many nodes it is hosting, so the group
             # is still obvious when it scrolls past the top of the table
             suffix = f"  (+{node.shared_count - 1} nodes)" if grouped and first_of_group else ""
@@ -552,6 +593,7 @@ class TerminalUI:
 
             rows.append(row)
 
+        self.nodes_table.empty_message = self._empty_table_message()
         self.nodes_table.set_data(rows)
         
         # Sync selection state with table component
@@ -638,6 +680,14 @@ class TerminalUI:
             "  • Real-time CPU, memory, and GPU monitoring",
             "  • Automatic node discovery via registry",
             "  • Color-coded usage indicators",
+            "",
+            "Node Discovery:",
+            "  ~name    - Found on the ROS graph, not registered. Its PID",
+            "             was inferred from the DDS GUID, so it is a weaker",
+            "             claim than a node that identified itself.",
+            "             The status bar shows the middleware in use and",
+            "             whether auto-discovery works with it. When it does",
+            "             not, nodes must call register_node() to appear.",
             "",
             "Component Containers:",
             "  -        - Nodes indented under a container run inside that",

--- a/tests/test_graph_discovery.py
+++ b/tests/test_graph_discovery.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Graph auto-discovery: GUID parsing, PID matching, and safe degradation.
+
+The parsing and matching logic is deliberately pure, so none of this needs a
+running ROS 2 system.
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from ros2top.graph_discovery import (  # noqa: E402
+    DiscoveryMode, GraphDiscovery, carries_own_pid, host_id, pid_low16, resolve,
+)
+
+
+def _prefix(host=b'\xc9\x6e', pid=0, tail=b'\xab\xec\x00\x00\x00\x00'):
+    """Build a Fast DDS style 12-byte GUID prefix"""
+    return b'\x01\x0f' + host + (pid & 0xFFFF).to_bytes(2, 'little') + tail
+
+
+def test_guid_layout_matches_observed_bytes():
+    """Real capture: PID 3666305 produced prefix 01 0f c9 6e 81 f1 ab ec ..."""
+    observed = bytes.fromhex('010fc96e81f1abec00000000')
+    assert pid_low16(observed) == 3666305 & 0xFFFF
+    assert host_id(observed) == b'\xc9\x6e'
+    # only the low 16 bits are present, never the whole PID
+    assert pid_low16(observed) != 3666305
+    print('OK: GUID layout matches the captured bytes')
+
+
+def test_self_test_detects_unsupported_middleware():
+    assert carries_own_pid(_prefix(pid=os.getpid()), os.getpid())
+    # Zenoh/Cyclone put something else there entirely
+    assert not carries_own_pid(_prefix(pid=os.getpid() + 1), os.getpid())
+    print('OK: self-test distinguishes PID-bearing GUIDs')
+
+
+def test_resolves_composable_nodes_to_one_pid():
+    host = b'\xc9\x6e'
+    container = _prefix(host, 4242)
+    standalone = _prefix(host, 4243)
+    nodes = {
+        container: {'/my_container', '/talker', '/listener'},
+        standalone: {'/talker'},   # same name, different process
+    }
+    got = resolve(nodes, [4242, 4243], host)
+
+    assert sorted(got) == sorted([
+        ('/my_container', 4242), ('/talker', 4242), ('/listener', 4242),
+        ('/talker', 4243),
+    ]), got
+    print('OK: composable nodes resolve to their container, duplicates kept apart')
+
+
+def test_remote_host_is_rejected():
+    """A node on another machine must never be matched to a local PID."""
+    ours, theirs = b'\xc9\x6e', b'\xde\xad'
+    nodes = {_prefix(theirs, 4242): {'/remote_node'}}
+    assert resolve(nodes, [4242], ours) == [], 'matched a node from another host'
+    # ... and the identical prefix on our own host does resolve
+    assert resolve({_prefix(ours, 4242): {'/local'}}, [4242], ours) == [('/local', 4242)]
+    print('OK: remote nodes rejected by host id')
+
+
+def test_ambiguous_low16_reports_nothing():
+    """16 bits collide; with two candidates there is no way to pick, so don't."""
+    host = b'\xc9\x6e'
+    colliding = [4242, 4242 + 0x10000]
+    assert (4242 & 0xFFFF) == (colliding[1] & 0xFFFF)
+    nodes = {_prefix(host, 4242): {'/ambiguous'}}
+    assert resolve(nodes, colliding, host) == [], 'guessed between two candidates'
+    print('OK: ambiguous PID low16 yields nothing rather than a guess')
+
+
+def test_unknown_pid_reports_nothing():
+    host = b'\xc9\x6e'
+    nodes = {_prefix(host, 9999): {'/vanished'}}
+    assert resolve(nodes, [4242], host) == []
+    print('OK: unmatched node omitted')
+
+
+def test_degrades_without_rclpy(monkeypatch=None):
+    """No ROS sourced must mean MANUAL mode, not a crash."""
+    import builtins
+    real_import = builtins.__import__
+
+    def no_rclpy(name, *a, **kw):
+        if name == 'rclpy' or name.startswith('rclpy.'):
+            raise ImportError('No module named rclpy')
+        return real_import(name, *a, **kw)
+
+    builtins.__import__ = no_rclpy
+    try:
+        d = GraphDiscovery()
+        # the import happens on the worker, so give it a moment to report back
+        for _ in range(50):
+            if 'rclpy' in d.status.reason:
+                break
+            time.sleep(0.05)
+        status = d.status
+        assert status.mode is DiscoveryMode.MANUAL, status
+        assert 'rclpy' in status.reason
+        assert d.get_nodes_with_pids() == []
+        d.shutdown()
+    finally:
+        builtins.__import__ = real_import
+    print('OK: missing rclpy degrades to manual mode')
+
+
+def test_short_rmw_names():
+    from ros2top.graph_discovery import DiscoveryStatus
+    s = DiscoveryStatus(DiscoveryMode.AUTO, 'rmw_fastrtps_cpp', '')
+    assert s.short_rmw == 'fastrtps'
+    assert DiscoveryStatus(DiscoveryMode.MANUAL, 'rmw_zenoh_cpp', '').short_rmw == 'zenoh'
+    assert DiscoveryStatus(DiscoveryMode.MANUAL, 'unknown', '').short_rmw == 'unknown'
+    print('OK: RMW names shortened for the status bar')
+
+
+def test_placeholder_and_internal_nodes_are_not_reported():
+    """rmw emits sentinels for endpoints it has not matched yet; they are not nodes."""
+    from ros2top.graph_discovery import _is_reportable
+
+    assert not _is_reportable('_NODE_NAME_UNKNOWN_', '/'), 'phantom node reported'
+    assert not _is_reportable('talker', '_NODE_NAMESPACE_UNKNOWN_')
+    assert not _is_reportable('_ros2cli_daemon_62_abc', '/')
+    assert not _is_reportable('ros2top_discovery_1234', '/'), 'another ros2top reported'
+    # real nodes still pass
+    assert _is_reportable('talker', '/')
+    assert _is_reportable('my_container', '/robot')
+    print('OK: placeholders, ros2cli daemon and other ros2top instances filtered')
+
+
+def test_registry_wins_over_graph():
+    """A node that registered must not also appear as an auto-discovered row."""
+    from ros2top.node_monitor import NodeMonitor
+
+    monitor = NodeMonitor(refresh_interval=0.0, auto_discovery=False)
+    pid = os.getpid()
+    # registry reports it, and the graph would report the very same (name, pid)
+    monitor.discovery = _FakeDiscovery([('/dup', pid), ('/only_graph', pid)])
+    import ros2top.node_monitor as nm
+    real = nm.get_registered_nodes
+    nm.get_registered_nodes = lambda: [('/dup', pid)]
+    try:
+        found = monitor._get_all_processes_to_monitor()
+    finally:
+        nm.get_registered_nodes = real
+
+    assert found.count(('/dup', pid)) == 1, f'duplicated: {found}'
+    assert ('/only_graph', pid) in found
+    # only the graph-only node is marked
+    assert monitor._auto_names == {('/only_graph', pid)}, monitor._auto_names
+    print('OK: registry entry wins, graph-only node marked')
+
+
+def test_container_heads_group_without_registration_times():
+    """Auto-discovered nodes share a create_time, so cmdline breaks the tie."""
+    from ros2top.node_monitor import NodeMonitor
+
+    monitor = NodeMonitor(refresh_interval=0.0, auto_discovery=False)
+    pid = os.getpid()
+    # every node in a container reports the same process create time
+    monitor._get_process_start_time = lambda name, proc: 1000.0
+    monitor._cmdlines[pid] = 'component_container --ros-args -r __node:=my_container'
+    monitor._add_new_nodes_with_pids([
+        ('/listener', pid), ('/my_container', pid), ('/talker', pid)])
+
+    names = [i.name for i in monitor.get_node_info_list()]
+    assert names[0] == '/my_container', f'container not at head: {names}'
+    print('OK: cmdline names the container when start times tie')
+
+
+class _FakeDiscovery:
+    def __init__(self, nodes):
+        self._nodes = nodes
+
+    def get_nodes_with_pids(self):
+        return list(self._nodes)
+
+    @property
+    def status(self):
+        from ros2top.graph_discovery import DiscoveryStatus
+        return DiscoveryStatus(DiscoveryMode.AUTO, 'rmw_fake', '')
+
+    def shutdown(self):
+        pass
+
+
+if __name__ == '__main__':
+    test_guid_layout_matches_observed_bytes()
+    test_self_test_detects_unsupported_middleware()
+    test_resolves_composable_nodes_to_one_pid()
+    test_remote_host_is_rejected()
+    test_ambiguous_low16_reports_nothing()
+    test_unknown_pid_reports_nothing()
+    test_degrades_without_rclpy()
+    test_short_rmw_names()
+    test_placeholder_and_internal_nodes_are_not_reported()
+    test_registry_wins_over_graph()
+    test_container_heads_group_without_registration_times()

--- a/tests/test_ros2top.py
+++ b/tests/test_ros2top.py
@@ -21,16 +21,17 @@ import psutil
 class TestROS2Utils(unittest.TestCase):
     """Test ROS2 utility functions"""
     
-    @patch('subprocess.run')
-    def test_is_ros2_available_success(self, mock_run):
+    @patch('ros2top.ros2_utils.shutil.which')
+    def test_is_ros2_available_success(self, mock_which):
         """Test ROS2 availability check when ROS2 is available"""
-        mock_run.return_value.returncode = 0
+        mock_which.return_value = '/opt/ros/jazzy/bin/ros2'
         self.assertTrue(is_ros2_available())
-    
-    @patch('subprocess.run')
-    def test_is_ros2_available_failure(self, mock_run):
+        mock_which.assert_called_once_with('ros2')
+
+    @patch('ros2top.ros2_utils.shutil.which')
+    def test_is_ros2_available_failure(self, mock_which):
         """Test ROS2 availability check when ROS2 is not available"""
-        mock_run.side_effect = FileNotFoundError()
+        mock_which.return_value = None
         self.assertFalse(is_ros2_available())
     
     @patch('ros2top.ros2_utils.get_registered_nodes')


### PR DESCRIPTION
ros2top only sees nodes that call register_node(). Everything else is invisible, and an uninstrumented system shows a bare table header with no explanation.

On Fast DDS (the ROS 2 default) the DDS GUID carries the low 16 bits of the owning process's PID, so nodes can be mapped to processes from the graph alone. This adds that as a second discovery source, on by default, with --no-auto-discovery to opt out.

Auto-discovered nodes are marked ~, since their PID is inferred rather than self-reported:

```bash
PID      Uptime   %CPU  RAM(MB)  Node Name
1630393  01m:37s  0.1   31.8     ~/my_container  (+2 nodes)
         01m:37s             - ~/listener
         01m:37s             - ~/talker
```
Zenoh and Cyclone carry no PID, so discovery is unavailable there. Rather than keep a vendor allowlist that rots when a layout changes, ros2top asks the graph where its own node lives and checks whether the answer is its PID — proving the capability instead of assuming it. The status bar reports the outcome, and an empty table now explains itself:

```bash
ROS2✓ | RMW:fastrtps | Auto✓ | Nodes:4
ROS2✓ | RMW:zenoh | Auto✗ register | Nodes:0
```

### Guards
- Host filtering: Nodes on other machines are skipped; their PID low16 could collide with a local process and show someone else's CPU.
- No guessing. 16 PID bits collide, so candidates are narrowed to local ROS processes and a node with more than one match is omitted entirely.

### Testing
41 unit tests. GUID parsing, matching and filtering are pure functions, so they need no ROS. Verified live against C++, Python, lifecycle, native, namespaced, duplicate-named and composable nodes. Every PID checked against `/proc` ground truth plus the Zenoh, --no-auto-discovery and ROS-not-sourced paths.