### PR TITLE
Feat/ros2cli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A real-time monitor for ROS2 nodes showing CPU, RAM, and GPU usage - like `htop`
 - 🖥️ **Terminal-based interface** using curses
 - 🔄 **Auto-refresh** with configurable intervals
 - 🏷️ **Process tree awareness** (includes child processes)
+- 🔌 **`ros2 top` integration** - available as a ros2 CLI sub-command
 - 🛰️ **Automatic node discovery** from the ROS graph, with no code changes (on supported middleware)
 - 📦 **Component container aware** - composable nodes are grouped under the container hosting them
 - 📝 **Node registration API** for reliable node-to-monitor communication
@@ -57,9 +58,16 @@ pip install -e .
 ### Basic Usage
 
 ```bash
-# Run ros2top
+# Run standalone
 ros2top
+
+# Or as a ros2 CLI sub-command, wherever ROS 2 is installed
+ros2 top
 ```
+
+Both are the same program: `ros2top` registers itself with `ros2cli` through an
+entry point, so `ros2 top` appears in `ros2 --help` with no changes to ros2cli.
+Every option below works with either form.
 
 ### Command Line Options
 
@@ -68,6 +76,8 @@ ros2top --help                # Show help
 ros2top --refresh 2          # Refresh every 2 seconds (default: 5)
 ros2top --no-auto-discovery  # Only show nodes that registered themselves
 ros2top --version           # Show version
+
+ros2 top --refresh 2         # identical, via the ros2 CLI
 ```
 
 ### Interactive Controls
@@ -123,6 +133,8 @@ The top panel shows real-time system information:
 
 ```bash
 ros2top --refresh 2
+# or
+ros2 top --refresh 2
 ```
 
 ## How It Works
@@ -234,6 +246,8 @@ ros2top/
 │   ├── node_monitor.py     # Core monitoring logic
 │   ├── node_registry.py    # Node registration system
 │   ├── graph_discovery.py  # Automatic node discovery from the ROS graph
+│   ├── command/            # ros2cli plugin exposing `ros2 top`
+│   │   └── top.py
 │   ├── gpu_monitor.py      # GPU monitoring
 │   ├── ros2_utils.py       # ROS2 utilities
 │   └── ui/                 # User interface components

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A real-time monitor for ROS2 nodes showing CPU, RAM, and GPU usage - like `htop` but for ROS2 nodes.
 
+Tested on **Humble**, **Jazzy**, **Kilted** and **Rolling**.
+
 <!-- ![ROS2Top Demo]() -->
 
 ## Features
@@ -18,13 +20,43 @@ A real-time monitor for ROS2 nodes showing CPU, RAM, and GPU usage - like `htop`
 - 📦 **Component container aware** - composable nodes are grouped under the container hosting them
 - 📝 **Node registration API** for reliable node-to-monitor communication
 
-## Installation
+## Supported ROS 2 distributions
 
-### From PyPI (when published)
+Verified in the official `ros:<distro>` containers: installed with `pip`, then
+checked for the full unit suite, the `ros2 top` sub-command, and live
+auto-discovery of C++, Python and composable nodes against their real PIDs.
+
+| Distribution | Ubuntu | Default RMW | Auto-discovery | `ros2 top` | Status |
+| ------------ | ------ | ----------- | -------------- | ---------- | ------ |
+| **Humble** Hawksbill | 22.04 | `rmw_fastrtps_cpp` | ✅ | ✅ | Supported |
+| **Jazzy** Jalisco | 24.04 | `rmw_fastrtps_cpp` | ✅ | ✅ | Supported |
+| **Kilted** Kaiju | 24.04 | `rmw_fastrtps_cpp` | ✅ | ✅ | Supported |
+| **Rolling** Ridley | 24.04 | `rmw_fastrtps_cpp` | ✅ | ✅ | Supported |
+
+Iron Irwini is not tested; it reached end of life in November 2024.
+
+Auto-discovery depends on the **middleware**, not the distribution. All four
+default to Fast DDS, whose GUID carries the process id. Under `rmw_zenoh_cpp` or
+Cyclone DDS the graph carries no PID, so nodes must register themselves - ros2top
+detects this and says so in the status bar rather than showing an empty table.
+
+## Installation
 
 ```bash
 pip install ros2top
 ```
+
+On **Ubuntu 24.04 and newer** (Jazzy, Kilted, Rolling) the system interpreter is
+marked externally managed (PEP 668), so pip needs to be told explicitly:
+
+```bash
+pip install --break-system-packages ros2top
+# or, preferred, a venv that can still see the ROS 2 packages:
+python3 -m venv --system-site-packages ~/.venvs/ros2top
+source ~/.venvs/ros2top/bin/activate && pip install ros2top
+```
+
+Humble (Ubuntu 22.04) needs no flag.
 
 ### From Source
 
@@ -33,6 +65,12 @@ git clone https://github.com/AhmedARadwan/ros2top.git
 cd ros2top
 pip install -e .
 ```
+
+> **Note:** installing *from source* needs pip 23 or newer to read this
+> project's `pyproject.toml` metadata. The pip 22.0.2 that ships with Ubuntu
+> 22.04 installs an empty `UNKNOWN-0.0.0` package instead, and reports success.
+> Run `pip install --upgrade pip` first, or install the released wheel with
+> `pip install ros2top`, which works on every version tested.
 
 ## Requirements
 
@@ -196,6 +234,15 @@ whole process, taking every node in it - the kill dialog warns before it does.
 
 - Install NVIDIA drivers
 - Install pynvml: `pip install pynvml`
+
+### `pip install` succeeded but `ros2top` is missing
+
+If you installed from source on Ubuntu 22.04, check what pip actually installed:
+
+```bash
+pip show ros2top      # 'UNKNOWN 0.0.0' means pip was too old
+pip install --upgrade pip && pip install -e .
+```
 
 ### Nodes not showing up
 

--- a/examples/cpp/README.md
+++ b/examples/cpp/README.md
@@ -49,6 +49,9 @@ See the [package README](example_monitored_node/README.md) for detailed usage in
 
    ```bash
    ros2top
+
+   # or, equivalently, as a ros2 CLI sub-command
+   ros2 top
    ```
 
 ## C++ API Overview

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -37,6 +37,9 @@ A complete example of a ROS2 node that registers itself with ros2top for monitor
    ```bash
    # In another terminal, run ros2top to see the registered node
    ros2top
+
+   # or, equivalently, as a ros2 CLI sub-command
+   ros2 top
    ```
 
 **What you'll see:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ dependencies = [
 [project.scripts]
 ros2top = "ros2top.main:main"
 
+# Makes the same monitor available as `ros2 top` wherever ros2cli is installed.
+# ros2cli finds it by entry point, so nothing in ros2cli has to change.
+[project.entry-points."ros2cli.command"]
+top = "ros2top.command.top:TopCommand"
+
 [project.urls]
 Homepage = "https://github.com/AhmedARadwan/ros2top"
 "Bug Reports" = "https://github.com/AhmedARadwan/ros2top/issues"

--- a/ros2top/command/top.py
+++ b/ros2top/command/top.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""
+ros2cli plugin exposing ros2top as `ros2 top`.
+
+Discovered through the `ros2cli.command` entry point declared in
+pyproject.toml, so installing ros2top alongside ROS 2 is all that is needed --
+no changes to ros2cli itself.
+"""
+
+from ros2cli.command import CommandExtension
+
+from ..main import DESCRIPTION, add_arguments, run
+
+
+class TopCommand(CommandExtension):
+    """Real-time monitor for ROS 2 nodes showing CPU, RAM, and GPU usage."""
+
+    # ros2cli prints the first line of this docstring in `ros2 --help`, so it
+    # doubles as the command's one-line summary.
+    __doc__ = DESCRIPTION + '.'
+
+    def add_arguments(self, parser, cli_name):
+        add_arguments(parser)
+
+    def main(self, *, parser, args):
+        return run(args)

--- a/ros2top/graph_discovery.py
+++ b/ros2top/graph_discovery.py
@@ -47,6 +47,7 @@ _PID = slice(4, 6)
 
 
 class DiscoveryMode(Enum):
+    STARTING = 'starting'  # still joining the graph; no verdict yet
     AUTO = 'auto'       # the graph gives us node -> PID, no registration needed
     MANUAL = 'manual'   # nodes must register themselves to be seen
 
@@ -59,6 +60,11 @@ class DiscoveryStatus(NamedTuple):
     @property
     def is_auto(self) -> bool:
         return self.mode is DiscoveryMode.AUTO
+
+    @property
+    def is_settled(self) -> bool:
+        """Whether discovery has decided. False only during the first moments."""
+        return self.mode is not DiscoveryMode.STARTING
 
     @property
     def short_rmw(self) -> str:
@@ -193,8 +199,10 @@ class GraphDiscovery:
         self._period = period
         self._lock = threading.Lock()
         self._nodes: List[Tuple[str, int]] = []
+        # Shown for the second or so before the graph is reachable, so it has
+        # to read as progress rather than as a verdict.
         self._status = DiscoveryStatus(
-            DiscoveryMode.MANUAL, 'unknown', 'discovery has not started yet')
+            DiscoveryMode.STARTING, 'unknown', 'Looking for nodes...')
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
         self._context = None

--- a/ros2top/main.py
+++ b/ros2top/main.py
@@ -10,24 +10,31 @@ from .node_monitor import NodeMonitor
 from .ui.terminal_ui import run_ui, show_error_message
 
 
-def create_argument_parser():
-    """Create command line argument parser"""
-    parser = argparse.ArgumentParser(
-    description='Real-time monitor for ROS2 nodes showing CPU, RAM, and GPU usage',
-    formatter_class=argparse.RawDescriptionHelpFormatter,
-    epilog="""
+DESCRIPTION = 'Real-time monitor for ROS2 nodes showing CPU, RAM, and GPU usage'
+
+EPILOG = """
 Examples:
-    ros2top                    # Run with default settings
-    ros2top --refresh 2        # Refresh every 2 seconds
+    ros2top                      # Run with default settings
+    ros2top --refresh 2          # Refresh every 2 seconds
     ros2top --no-auto-discovery  # Only registered nodes
+
+    Also available as a ros2 CLI sub-command:
+    ros2 top                     # identical to `ros2top`
 
     Controls:
     q/Q - Quit
     r/R - Force refresh node list
     h/H - Show help
+"""
+
+
+def add_arguments(parser):
     """
-    )
-    
+    Add ros2top's arguments to a parser.
+
+    Shared with the ros2cli plugin, which is handed a subparser rather than
+    creating its own, so `ros2top` and `ros2 top` cannot drift apart.
+    """
     parser.add_argument(
         '--refresh', '-r',
         type=float,
@@ -51,6 +58,16 @@ Examples:
     return parser
 
 
+def create_argument_parser():
+    """Create command line argument parser for the standalone `ros2top`"""
+    parser = argparse.ArgumentParser(
+        description=DESCRIPTION,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=EPILOG,
+    )
+    return add_arguments(parser)
+
+
 def check_requirements():
     """Check if required dependencies are available"""
     try:
@@ -68,42 +85,48 @@ def check_requirements():
     return True
 
 
-def main():
-    """Main entry point"""
-    parser = create_argument_parser()
-    args = parser.parse_args()
-    
+def run(args) -> int:
+    """
+    Run the monitor with already-parsed arguments, returning an exit code.
+
+    Returns rather than exits so the ros2cli plugin can hand the code back to
+    ros2cli instead of tearing the process down from underneath it.
+    """
     # Check requirements
     if not check_requirements():
-        sys.exit(1)
-    
+        return 1
+
     # Validate arguments
     if args.refresh <= 0:
         show_error_message("Refresh interval must be positive")
-        sys.exit(1)
-    
+        return 1
+
     # Create node monitor
     try:
         monitor = NodeMonitor(refresh_interval=args.refresh,
                               auto_discovery=not args.no_auto_discovery)
     except Exception as e:
         show_error_message(f"Failed to initialize node monitor: {e}")
-        sys.exit(1)
-    
+        return 1
+
     # Run UI
     try:
-        success = run_ui(monitor)
-        if not success:
-            sys.exit(1)
+        return 0 if run_ui(monitor) else 1
     except KeyboardInterrupt:
         print("\nGoodbye!")
+        return 0
     except Exception as e:
         show_error_message(f"Unexpected error: {e}")
-        sys.exit(1)
+        return 1
     finally:
         # Cleanup background threads
         if hasattr(monitor, 'cleanup'):
             monitor.cleanup()
+
+
+def main():
+    """Entry point for the standalone `ros2top` command"""
+    sys.exit(run(create_argument_parser().parse_args()))
 
 
 if __name__ == '__main__':

--- a/ros2top/ui/terminal_ui.py
+++ b/ros2top/ui/terminal_ui.py
@@ -421,7 +421,12 @@ class TerminalUI:
                 # Name the middleware and whether it lets us find nodes on our
                 # own, so "no nodes" is never a mystery
                 discovery = self.monitor.get_discovery_status()
-                auto = "Auto✓" if discovery.is_auto else "Auto✗ register"
+                if not discovery.is_settled:
+                    auto = "Auto…"          # no verdict yet, do not claim one
+                elif discovery.is_auto:
+                    auto = "Auto✓"
+                else:
+                    auto = "Auto✗ register"
                 # Only claim to know the middleware when we actually asked it
                 rmw = (f"RMW:{discovery.short_rmw} | "
                        if discovery.short_rmw not in ('disabled', 'unknown') else "")
@@ -495,6 +500,11 @@ class TerminalUI:
     def _empty_table_message(self) -> List[str]:
         """Explain an empty table, since 'no nodes' has several causes"""
         status = self.monitor.get_discovery_status()
+        if not status.is_settled:
+            # Still joining the graph. Telling people to register nodes before
+            # we have even looked would be advice we might retract a second later.
+            return ["", status.reason]
+
         if status.is_auto:
             return [
                 "",
@@ -655,7 +665,7 @@ class TerminalUI:
         height, width = self.stdscr.getmaxyx()
         
         help_lines = [
-            "ros2top Enhanced Terminal UI",
+            "ros2top Enhanced Terminal UI  (also: ros2 top)",
             "",
             "Global Controls:",
             "  q/Q      - Quit application",

--- a/tests/test_graph_discovery.py
+++ b/tests/test_graph_discovery.py
@@ -119,6 +119,19 @@ def test_short_rmw_names():
     print('OK: RMW names shortened for the status bar')
 
 
+def test_starting_state_makes_no_claim():
+    """Before the graph is reachable ros2top must not advise registering nodes."""
+    from ros2top.graph_discovery import DiscoveryStatus
+
+    starting = DiscoveryStatus(DiscoveryMode.STARTING, 'unknown', 'Looking for nodes...')
+    assert not starting.is_settled, 'startup reported as a verdict'
+    assert not starting.is_auto
+
+    for mode in (DiscoveryMode.AUTO, DiscoveryMode.MANUAL):
+        assert DiscoveryStatus(mode, 'rmw_x', '').is_settled, mode
+    print('OK: startup state is distinct from a verdict')
+
+
 def test_placeholder_and_internal_nodes_are_not_reported():
     """rmw emits sentinels for endpoints it has not matched yet; they are not nodes."""
     from ros2top.graph_discovery import _is_reportable
@@ -198,6 +211,7 @@ if __name__ == '__main__':
     test_unknown_pid_reports_nothing()
     test_degrades_without_rclpy()
     test_short_rmw_names()
+    test_starting_state_makes_no_claim()
     test_placeholder_and_internal_nodes_are_not_reported()
     test_registry_wins_over_graph()
     test_container_heads_group_without_registration_times()

--- a/tests/test_ros2cli_command.py
+++ b/tests/test_ros2cli_command.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""`ros2 top` must accept exactly what `ros2top` accepts, and share its code."""
+
+import argparse
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from ros2top.main import add_arguments, create_argument_parser  # noqa: E402
+
+
+def _options(parser):
+    return {opt for action in parser._actions for opt in action.option_strings}
+
+
+class TestRos2CliCommand(unittest.TestCase):
+
+    def test_standalone_and_plugin_share_arguments(self):
+        """Both entry points call the same add_arguments, so they cannot drift."""
+        standalone = create_argument_parser()
+        plugin_parser = argparse.ArgumentParser()
+        add_arguments(plugin_parser)
+
+        self.assertEqual(_options(standalone), _options(plugin_parser))
+        self.assertIn('--refresh', _options(plugin_parser))
+        self.assertIn('--no-auto-discovery', _options(plugin_parser))
+
+    def test_defaults_match(self):
+        plugin_parser = argparse.ArgumentParser()
+        add_arguments(plugin_parser)
+        a = plugin_parser.parse_args([])
+        b = create_argument_parser().parse_args([])
+        self.assertEqual(a.refresh, b.refresh)
+        self.assertEqual(a.no_auto_discovery, b.no_auto_discovery)
+
+    def test_entry_point_is_declared(self):
+        """pyproject must advertise the command or ros2cli will never find it."""
+        root = os.path.join(os.path.dirname(__file__), '..')
+        with open(os.path.join(root, 'pyproject.toml')) as f:
+            content = f.read()
+        self.assertIn('[project.entry-points."ros2cli.command"]', content)
+        self.assertIn('top = "ros2top.command.top:TopCommand"', content)
+
+    @unittest.skipUnless(
+        __import__('importlib').util.find_spec('ros2cli'),
+        'ros2cli not installed (ROS 2 not sourced)')
+    def test_command_extension_contract(self):
+        """The plugin must satisfy the interface ros2cli calls into."""
+        from ros2cli.command import CommandExtension
+        from ros2top.command.top import TopCommand
+
+        self.assertTrue(issubclass(TopCommand, CommandExtension))
+        cmd = TopCommand()
+        # ros2cli hands the verb a parser, then calls main(parser=, args=)
+        parser = argparse.ArgumentParser()
+        cmd.add_arguments(parser, 'top')
+        self.assertIn('--refresh', _options(parser))
+        self.assertTrue(TopCommand.__doc__.strip(),
+                        'ros2 --help prints this docstring as the summary')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_ros2top.py
+++ b/tests/test_ros2top.py
@@ -114,14 +114,14 @@ class TestNodeMonitor(unittest.TestCase):
     def test_node_monitor_init(self, mock_ros2_available):
         """Test node monitor initialization"""
         mock_ros2_available.return_value = True
-        monitor = NodeMonitor()
+        monitor = NodeMonitor(auto_discovery=False)
         self.assertTrue(monitor.is_ros2_available())
     
     @patch('ros2top.node_monitor.is_ros2_available')
     def test_node_monitor_no_ros2(self, mock_ros2_available):
         """Test node monitor when ROS2 is not available"""
         mock_ros2_available.return_value = False
-        monitor = NodeMonitor()
+        monitor = NodeMonitor(auto_discovery=False)
         self.assertFalse(monitor.is_ros2_available())
         
         # Should still be able to update nodes (for registry-based monitoring)
@@ -136,7 +136,7 @@ class TestNodeMonitor(unittest.TestCase):
         mock_ros2_available.return_value = False
         mock_get_registered.return_value = [("/test_node", 1234)]
         
-        monitor = NodeMonitor(refresh_interval=0.1)  # Fast refresh for testing
+        monitor = NodeMonitor(refresh_interval=0.1, auto_discovery=False)  # Fast refresh for testing
         result = monitor.update_nodes()
         self.assertTrue(result)
     
@@ -166,7 +166,7 @@ class TestNodeMonitor(unittest.TestCase):
     def test_node_monitor_system_info(self, mock_ros2_available):
         """Test getting system information"""
         mock_ros2_available.return_value = True
-        monitor = NodeMonitor()
+        monitor = NodeMonitor(auto_discovery=False)
         
         system_info = monitor.get_system_info()
         
@@ -215,7 +215,7 @@ class TestUIFormatting(unittest.TestCase):
         mock_time.return_value = 1234567890.0
         
         # Create a UI instance
-        monitor = NodeMonitor()
+        monitor = NodeMonitor(auto_discovery=False)
         ui = TerminalUI(monitor)
         
         # Test various cases
@@ -254,7 +254,7 @@ class TestRegistryStartTime(unittest.TestCase):
         mock_process.return_value = mock_proc
 
         # Create monitor and test start time retrieval
-        monitor = NodeMonitor()
+        monitor = NodeMonitor(auto_discovery=False)
         start_time = monitor._get_process_start_time("/test_node", mock_proc)
 
         # Should use registry time, not psutil time
@@ -276,7 +276,7 @@ class TestRegistryStartTime(unittest.TestCase):
         mock_process.return_value = mock_proc
         
         # Create monitor and test start time retrieval
-        monitor = NodeMonitor()
+        monitor = NodeMonitor(auto_discovery=False)
         start_time = monitor._get_process_start_time("/test_node", mock_proc)
         
         # Should use psutil time as fallback
@@ -289,7 +289,7 @@ class TestKillProcess(unittest.TestCase):
     
     def setUp(self):
         """Set up test environment"""
-        self.monitor = NodeMonitor()
+        self.monitor = NodeMonitor(auto_discovery=False)
     
     @patch('psutil.Process')
     def test_kill_process_success(self, mock_process_class):

--- a/tests/test_shared_process.py
+++ b/tests/test_shared_process.py
@@ -24,7 +24,7 @@ def test_shared_pid_measured_once():
     container = _busy_process()
     solo = _busy_process()
     try:
-        monitor = NodeMonitor(refresh_interval=0.0)
+        monitor = NodeMonitor(refresh_interval=0.0, auto_discovery=False)
         # Three composable nodes in one container + one standalone node.
         monitor._add_new_nodes_with_pids([
             ('/talker', container.pid),
@@ -94,7 +94,7 @@ def test_display_order_matches_kill_order():
     container = _busy_process()
     solo = _busy_process()
     try:
-        monitor = NodeMonitor(refresh_interval=0.0)
+        monitor = NodeMonitor(refresh_interval=0.0, auto_discovery=False)
         monitor._add_new_nodes_with_pids([
             ('/zzz_composed_later', container.pid),
             ('/aaa_other_process', solo.pid),
@@ -150,7 +150,7 @@ def test_kill_removes_every_node_in_the_process():
     container = _busy_process()
     solo = _busy_process()
     try:
-        monitor = NodeMonitor(refresh_interval=0.0)
+        monitor = NodeMonitor(refresh_interval=0.0, auto_discovery=False)
         monitor._add_new_nodes_with_pids([
             ('/my_container', container.pid),
             ('/talker', container.pid),
@@ -184,7 +184,7 @@ def test_kill_tolerates_key_without_pid_suffix():
     """Keys are 'name:pid', but the API must not break if one lacks the suffix."""
     proc = _busy_process()
     try:
-        monitor = NodeMonitor(refresh_interval=0.0)
+        monitor = NodeMonitor(refresh_interval=0.0, auto_discovery=False)
         monitor.processes['/legacy_node'] = psutil.Process(proc.pid)
         assert monitor.kill_process('/legacy_node', force=True)
         assert monitor.processes == {}


### PR DESCRIPTION
### Add `ros2 top`
ros2top is now available as a ros2 CLI sub-command:
```bash
ros2 top            # same program as `ros2top`
ros2 top --refresh 2
```
It's registered through the ros2cli.command entry point, so nothing in `ros2cli` changes This is the out-of-tree mechanism ros2cli's own README recommends.

`main.py` is split so both entry points share one code path: add_arguments() takes a parser instead of creating one (ros2cli hands the command a subparser), and run() returns an exit code instead of calling sys.exit(). So the two forms can't drift apart, and a test asserts they expose identical options.

### Verified across distributions
Tested in the official ros:<distro> containers — pip install, unit suite, ros2 top, and live auto-discovery of C++, Python and composable nodes checked against real PIDs:

| Distro  | Ubuntu | Result |
|----------|---------|--------|
| Humble  | 22.04   | ✅ |
| Jazzy   | 24.04   | ✅ |
| Kilted  | 24.04   | ✅ |
| Rolling | 24.04   | ✅ |

### Also fixed
Thirteen unit tests constructed `NodeMonitor` with discovery enabled, so each quietly joined the ROS graph. On Humble that segfaulted. `rclpy` imports type support lazily, and doing so on the discovery thread while pytest imports on the main thread crashes CPython 3.10. They never needed discovery, so they now pass auto_discovery=False. Repeating a real ros2top startup 15 times on Humble produced no crash, so this was pytest, not the application.